### PR TITLE
Fix mapper_parsing_exception issues during tests and replace index by update operation on db updates.

### DIFF
--- a/api/clan_test.go
+++ b/api/clan_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Clan API Handler", func() {
 				"publicID":         clanPublicID,
 				"name":             randomdata.FullName(randomdata.RandomGender),
 				"ownerPublicID":    player.PublicID,
-				"metadata":         map[string]interface{}{"x": 1},
+				"metadata":         map[string]interface{}{"x": "a"},
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
@@ -89,7 +89,7 @@ var _ = Describe("Clan API Handler", func() {
 				"publicID":         clanPublicID,
 				"name":             randomdata.FullName(randomdata.RandomGender),
 				"ownerPublicID":    player.PublicID,
-				"metadata":         map[string]interface{}{"x": 1},
+				"metadata":         map[string]interface{}{"x": "a"},
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
@@ -155,7 +155,7 @@ var _ = Describe("Clan API Handler", func() {
 				"publicID":         randomdata.FullName(randomdata.RandomGender),
 				"name":             randomdata.FullName(randomdata.RandomGender),
 				"ownerPublicID":    randomdata.FullName(randomdata.RandomGender),
-				"metadata":         map[string]interface{}{"x": 1},
+				"metadata":         map[string]interface{}{"x": "a"},
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
@@ -176,7 +176,7 @@ var _ = Describe("Clan API Handler", func() {
 				"publicID":         randomdata.FullName(randomdata.RandomGender),
 				"name":             strings.Repeat("a", 256),
 				"ownerPublicID":    player.PublicID,
-				"metadata":         map[string]interface{}{"x": 1},
+				"metadata":         map[string]interface{}{"x": "a"},
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
@@ -388,7 +388,7 @@ var _ = Describe("Clan API Handler", func() {
 
 			gameID := clan.GameID
 			publicID := clan.PublicID
-			metadata := map[string]interface{}{"x": 1}
+			metadata := map[string]interface{}{"x": "a"}
 
 			payload := map[string]interface{}{
 				"name":             clan.Name,
@@ -418,7 +418,7 @@ var _ = Describe("Clan API Handler", func() {
 			payload := map[string]interface{}{
 				"name":             strings.Repeat("s", 256),
 				"ownerPublicID":    owner.PublicID,
-				"metadata":         map[string]interface{}{"x": 1},
+				"metadata":         map[string]interface{}{"x": "a"},
 				"allowApplication": clan.AllowApplication,
 				"autoJoin":         clan.AutoJoin,
 			}
@@ -739,7 +739,7 @@ var _ = Describe("Clan API Handler", func() {
 				"publicID":         clanPublicID,
 				"name":             randomdata.FullName(randomdata.RandomGender),
 				"ownerPublicID":    player.PublicID,
-				"metadata":         map[string]interface{}{"x": 1},
+				"metadata":         map[string]interface{}{"x": "a"},
 				"allowApplication": true,
 				"autoJoin":         true,
 			}

--- a/api/player_test.go
+++ b/api/player_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Player API Handler", func() {
 			payload := map[string]interface{}{
 				"publicID": randomdata.FullName(randomdata.RandomGender),
 				"name":     randomdata.FullName(randomdata.RandomGender),
-				"metadata": map[string]interface{}{"x": 1},
+				"metadata": map[string]interface{}{"x": "a"},
 			}
 			status, body := PostJSON(a, GetGameRoute(game.PublicID, "/players"), payload)
 
@@ -94,7 +94,7 @@ var _ = Describe("Player API Handler", func() {
 			payload := map[string]interface{}{
 				"publicID": strings.Repeat("s", 256),
 				"name":     randomdata.FullName(randomdata.RandomGender),
-				"metadata": map[string]interface{}{"x": 1},
+				"metadata": map[string]interface{}{"x": "a"},
 			}
 			status, body := PostJSON(a, GetGameRoute(game.PublicID, "/players"), payload)
 

--- a/bench/helpers.go
+++ b/bench/helpers.go
@@ -70,7 +70,7 @@ func getClanPayload(ownerID, clanPublicID string) map[string]interface{} {
 		"publicID":         clanPublicID,
 		"name":             clanPublicID,
 		"ownerPublicID":    ownerID,
-		"metadata":         map[string]interface{}{"x": 1},
+		"metadata":         map[string]interface{}{"x": "a"},
 		"allowApplication": true,
 		"autoJoin":         true,
 	}
@@ -80,7 +80,7 @@ func getPlayerPayload(playerPublicID string) map[string]interface{} {
 	return map[string]interface{}{
 		"publicID": playerPublicID,
 		"name":     playerPublicID,
-		"metadata": map[string]interface{}{"x": 1},
+		"metadata": map[string]interface{}{"x": "a"},
 	}
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5d2a921cca2dde40ff4ac2e7e5aa79748762090c822e54337d554252a2250bb7
-updated: 2017-06-02T15:29:13.76236018-03:00
+hash: 981062184805818e48f7f102382ef8a29ed04aaa21e20a4615d80e5b18437791
+updated: 2017-09-02T21:42:20.803116097-03:00
 imports:
 - name: github.com/bitly/go-simplejson
   version: aabad6e819789e569bd6aabf444c935aa9ba1e44
@@ -119,11 +119,12 @@ imports:
   - reporters/stenographer
   - types
 - name: github.com/onsi/gomega
-  version: a78ae492d53aad5a7a232d0d0462c14c400e3ee7
+  version: c893efa28eb45626cdaa76c9f653b62488858837
   subpackages:
   - format
   - internal/assertion
   - internal/asyncassertion
+  - internal/oraclematcher
   - internal/testingtsupport
   - matchers
   - matchers/support/goraph/bipartitegraph
@@ -194,7 +195,9 @@ imports:
   version: 7394c112eae4dba7e96bfcfe738e6373d61772b4
   subpackages:
   - context
-  - context/ctxhttp
+  - html
+  - html/atom
+  - html/charset
 - name: golang.org/x/sys
   version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
   subpackages:
@@ -202,6 +205,20 @@ imports:
 - name: golang.org/x/text
   version: d69c40b4be55797923cec7457fac7a244d91a9b6
   subpackages:
+  - encoding
+  - encoding/charmap
+  - encoding/htmlindex
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/japanese
+  - encoding/korean
+  - encoding/simplifiedchinese
+  - encoding/traditionalchinese
+  - encoding/unicode
+  - internal/tag
+  - internal/utf8internal
+  - language
+  - runes
   - transform
   - unicode/norm
 - name: gopkg.in/gavv/httpexpect.v1
@@ -209,12 +226,12 @@ imports:
 - name: gopkg.in/gorp.v1
   version: c87af80f3cc5036b55b83d77171e156791085e2e
 - name: gopkg.in/olivere/elastic.v3
-  version: eb47340e05b08cae24208569de7240fecde96bd2
-  subpackages:
-  - backoff
-  - uritemplates
+  version: 5a75b7d18bca7420e68338600e8c9f611435f911
 - name: gopkg.in/olivere/elastic.v5
-  version: f1fd7305d0b6270192b27010fe1193568b18e4b6
+  version: edbef41beaacc2ee95e61af8faff04e67c01e268
+  subpackages:
+  - config
+  - uritemplates
 - name: gopkg.in/square/go-jose.v1
   version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/topfreegames/khan
 import:
 - package: github.com/onsi/gomega
+  version: ^1.2.0
 - package: github.com/Joker/jade
 - package: gopkg.in/gavv/httpexpect.v1
 - package: github.com/topfreegames/goose

--- a/models/game_test.go
+++ b/models/game_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Game Model", func() {
 				game.PublicID,
 				"game-new-name",
 				map[string]interface{}{"Member": 1, "Elder": 2, "CoLeader": 3},
-				map[string]interface{}{"x": 1},
+				map[string]interface{}{"x": "a"},
 				5, 4, 7, 1, 1, 1, 100, 1, 5, 15, 8, 25, 20,
 				"x", "y,z",
 			)
@@ -259,7 +259,7 @@ var _ = Describe("Game Model", func() {
 				gameID,
 				gameID,
 				map[string]interface{}{"Member": 1, "Elder": 2, "CoLeader": 3},
-				map[string]interface{}{"x": 1},
+				map[string]interface{}{"x": "a"},
 				5, 4, 7, 1, 1, 1, 100, 1, 10, 30, 8, 25, 20,
 				"x", "y,z",
 			)
@@ -302,7 +302,7 @@ var _ = Describe("Game Model", func() {
 				game.PublicID,
 				strings.Repeat("a", 256),
 				map[string]interface{}{"Member": 1, "Elder": 2, "CoLeader": 3},
-				map[string]interface{}{"x": 1},
+				map[string]interface{}{"x": "a"},
 				5, 4, 7, 1, 1, 0, 100, 1, 0, 0, 8, 25, 20,
 				"x", "y,z",
 			)

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Player Model", func() {
 
 				time.Sleep(time.Millisecond)
 
-				player.Metadata = map[string]interface{}{"x": 1}
+				player.Metadata = map[string]interface{}{"x": "a"}
 				count, err := testDb.Update(player)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(int(count)).To(Equal(1))
@@ -121,7 +121,7 @@ var _ = Describe("Player Model", func() {
 				_, player, err := CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				metadata := map[string]interface{}{"x": 1}
+				metadata := map[string]interface{}{"x": "a"}
 				updPlayer, err := UpdatePlayer(
 					testDb,
 					player.GameID,


### PR DESCRIPTION
Replace elasticsearch `index` operation by `update` when clan is updated. This behaviour allows for external customization of clan's metadata without interfering with khan and/or being overwritten by it on each clan update.

This pull request also fixes several `mapper_parsing_exception` issues when running tests. In some of them, a `metadata` attribute (`x`) would be defined as `integer` and in others, `string`.