### PR TITLE
Fix behaviour when there are no fields in hook metadata whitelist.

### DIFF
--- a/api/clan_helpers.go
+++ b/api/clan_helpers.go
@@ -99,7 +99,7 @@ func validateUpdateClanDispatch(game *models.Game, sourceClan *models.Clan, clan
 
 	if game.ClanUpdateMetadataFieldsHookTriggerWhitelist == "" {
 		log.D(cl, "Clan has no metadata whitelist for update hook")
-		return true
+		return false
 	}
 
 	log.D(cl, "Verifying fields for clan update hook dispatch...")

--- a/api/clan_test.go
+++ b/api/clan_test.go
@@ -888,7 +888,7 @@ var _ = Describe("Clan API Handler", func() {
 
 		Describe("Update Clan Hook", func() {
 			Describe("Without whitelist", func() {
-				It("Should call update clan hook", func() {
+				It("Should not call update clan hook", func() {
 					hooks, err := models.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/clanupdated",
 					}, models.ClanUpdatedHook)
@@ -900,7 +900,7 @@ var _ = Describe("Clan API Handler", func() {
 
 					gameID := clan.GameID
 					publicID := clan.PublicID
-					clanName := randomdata.FullName(randomdata.RandomGender)
+					clanName := clan.Name
 					ownerPublicID := owner.PublicID
 					metadata := map[string]interface{}{"new": "metadata"}
 
@@ -919,23 +919,9 @@ var _ = Describe("Clan API Handler", func() {
 					json.Unmarshal([]byte(body), &result)
 					Expect(result["success"]).To(BeTrue())
 
-					Eventually(func() int {
+					Consistently(func() int {
 						return len(*responses)
-					}).Should(Equal(1))
-
-					hookRes := (*responses)[0]["payload"].(map[string]interface{})
-					Expect(hookRes["gameID"]).To(Equal(hooks[0].GameID))
-					rClan := hookRes["clan"].(map[string]interface{})
-					Expect(rClan["publicID"]).To(Equal(publicID))
-					Expect(rClan["name"]).To(Equal(payload["name"]))
-					Expect(str(rClan["membershipCount"])).To(Equal("1"))
-					Expect(rClan["allowApplication"]).To(Equal(payload["allowApplication"]))
-					Expect(rClan["autoJoin"]).To(Equal(payload["autoJoin"]))
-					clanMetadata := rClan["metadata"].(map[string]interface{})
-					metadata = payload["metadata"].(map[string]interface{})
-					for k, v := range clanMetadata {
-						Expect(str(v)).To(Equal(str(metadata[k])))
-					}
+					}, 100*time.Millisecond, time.Millisecond).Should(Equal(0))
 				})
 			})
 

--- a/api/player_helpers.go
+++ b/api/player_helpers.go
@@ -33,7 +33,7 @@ func validateUpdatePlayerDispatch(game *models.Game, sourcePlayer *models.Player
 
 	if game.PlayerUpdateMetadataFieldsHookTriggerWhitelist == "" {
 		log.D(cl, "Player has no metadata whitelist for update hook")
-		return true
+		return false
 	}
 
 	log.D(cl, "Verifying fields for player update hook dispatch...")

--- a/api/player_test.go
+++ b/api/player_test.go
@@ -267,7 +267,7 @@ var _ = Describe("Player API Handler", func() {
 
 		Describe("Update Player Hook", func() {
 			Describe("Without Whitelist", func() {
-				It("Should call update player hook", func() {
+				It("Should not call update player hook", func() {
 					hooks, err := models.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/updated",
 					}, models.PlayerUpdatedHook)
@@ -291,21 +291,9 @@ var _ = Describe("Player API Handler", func() {
 					json.Unmarshal([]byte(body), &result)
 					Expect(result["success"]).To(BeTrue())
 
-					Eventually(func() int {
+					Consistently(func() int {
 						return len(*responses)
-					}).Should(Equal(1))
-
-					playerPayload := (*responses)[0]["payload"].(map[string]interface{})
-					Expect(playerPayload["gameID"]).To(Equal(gameID))
-					Expect(playerPayload["publicID"]).To(Equal(payload["publicID"]))
-					Expect(playerPayload["name"]).To(Equal(payload["name"]))
-					Expect(str(playerPayload["membershipCount"])).To(Equal("0"))
-					Expect(str(playerPayload["ownershipCount"])).To(Equal("0"))
-					playerMetadata := playerPayload["metadata"].(map[string]interface{})
-					metadata := payload["metadata"].(map[string]interface{})
-					for k, v := range playerMetadata {
-						Expect(v).To(Equal(metadata[k]))
-					}
+					}, 100*time.Millisecond, time.Millisecond).Should(Equal(0))
 				})
 			})
 			Describe("With Whitelist", func() {


### PR DESCRIPTION
When the whitelist is empty the expected behaviour is that the hooks will not be dispatched. The current behaviour is misleading since an empty whitelist allows all metadata updates to trigger hooks dispatchs.