### PR TITLE
Feature/reporting metrics to statsd

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,18 @@
 
 
 [[projects]]
+  name = "cloud.google.com/go"
+  packages = ["compute/metadata"]
+  revision = "4b98a6370e36d7a85192e7bad08a4ebd82eac2a8"
+  version = "v0.20.0"
+
+[[projects]]
+  name = "github.com/DataDog/datadog-go"
+  packages = ["statsd"]
+  revision = "0ddda6bee21174ef6c4873647cb0d6ec9cba996f"
+  version = "1.1.0"
+
+[[projects]]
   name = "github.com/Pallinder/go-randomdata"
   packages = ["."]
   revision = "01563c9f5c2dd648444bde7b3705a37698581364"
@@ -11,6 +23,12 @@
   packages = ["lib/go/thrift"]
   revision = "b2a4d4ae21c789b689dd162deb819665567f481c"
   version = "0.10.0"
+
+[[projects]]
+  name = "github.com/asaskevich/govalidator"
+  packages = ["."]
+  revision = "ccb8e960c48f04d6935e72476ae4a51028f9e22f"
+  version = "v9"
 
 [[projects]]
   name = "github.com/bitly/go-simplejson"
@@ -59,6 +77,19 @@
   version = "2.1"
 
 [[projects]]
+  name = "github.com/go-pg/pg"
+  packages = [
+    ".",
+    "internal",
+    "internal/parser",
+    "internal/pool",
+    "orm",
+    "types"
+  ]
+  revision = "24dfe0572921e42ffe1035f7afbd40f9d97cb8c8"
+  version = "v6.10.0"
+
+[[projects]]
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
   revision = "0b58b37b664c21f3010e836f1b931e1d0b0b0685"
@@ -68,6 +99,24 @@
   packages = ["gomock"]
   revision = "13f360950a79f5864a972c786a10a50e44b69541"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
+  version = "v1.1"
+
+[[projects]]
+  name = "github.com/gorilla/mux"
+  packages = ["."]
+  revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
+  version = "v1.6.1"
 
 [[projects]]
   name = "github.com/gosuri/uilive"
@@ -102,6 +151,12 @@
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/jinzhu/inflection"
+  packages = ["."]
+  revision = "04140366298a54a039076d798123ffa108fff46c"
 
 [[projects]]
   name = "github.com/jrallison/go-workers"
@@ -303,6 +358,12 @@
   revision = "0aa62d5ddceb50dbcb909d790b5345affd3669b6"
 
 [[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
+
+[[projects]]
   name = "github.com/spf13/afero"
   packages = [
     ".",
@@ -340,17 +401,23 @@
 [[projects]]
   name = "github.com/topfreegames/extensions"
   packages = [
+    "dogstatsd",
     "echo",
+    "echo/middleware",
     "gorp",
     "gorp/interfaces",
     "jaeger",
     "jaeger/echo",
     "jaeger/gorp",
+    "jaeger/mongo",
+    "middleware",
     "mongo",
-    "mongo/interfaces"
+    "mongo/interfaces",
+    "oauth2",
+    "pg/interfaces"
   ]
-  revision = "95cb7e36337d12d590d769d493f79aa9c3b5acf5"
-  version = "v5.6.3"
+  revision = "f6177c99f17f8ef000e4e3df2860e473b25f1f36"
+  version = "v5.9.0"
 
 [[projects]]
   branch = "master"
@@ -430,7 +497,8 @@
     "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
-    "ssh"
+    "ssh",
+    "ssh/terminal"
   ]
   revision = "986d3313588aa5c68f1df95eac956f79cf3b2c01"
 
@@ -438,11 +506,24 @@
   name = "golang.org/x/net"
   packages = [
     "context",
+    "context/ctxhttp",
     "html",
     "html/atom",
     "html/charset"
   ]
   revision = "7394c112eae4dba7e96bfcfe738e6373d61772b4"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt"
+  ]
+  revision = "fdc9e635145ae97e6c2cb777c48305600cf515cb"
 
 [[projects]]
   name = "golang.org/x/sys"
@@ -476,6 +557,23 @@
   revision = "d69c40b4be55797923cec7457fac7a244d91a9b6"
 
 [[projects]]
+  name = "google.golang.org/appengine"
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
+  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "v2"
   name = "gopkg.in/mgo.v2"
   packages = [
@@ -505,6 +603,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9cb9f504d42a1e7eef44072d4bdfc566b00f9907997bc417f7cb6bc8a80e72a4"
+  inputs-digest = "e9cbfbe8e6cf7bd1ecae6f70d6129a8a5bbf9b30c3c7c8700aa1579b5465e562"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@
 
 [[constraint]]
   name = "github.com/topfreegames/extensions"
-  version = "5.6.3"
+  version = "5.9.0"
 
 [[constraint]]
   name = "github.com/go-gorp/gorp"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -49,3 +49,10 @@ redis:
   database: 0
   pool: 30
   password: ""
+
+extensions:
+  dogstatsd:
+    host: localhost:8125
+    prefix: khan.
+    tags_prefix: ""
+    rate: 1

--- a/config/faulty.yaml
+++ b/config/faulty.yaml
@@ -11,3 +11,10 @@ newrelic:
 jaeger:
   disabled: false
   samplingProbability: 1.0
+
+ extensions:
+  dogstatsd:
+    host: localhost:8125
+    prefix: khan.
+    tags_prefix: ""
+    rate: 1

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -41,3 +41,10 @@ redis:
   database: 0
   pool: 30
   password: ""
+
+extensions:
+  dogstatsd:
+    host: localhost:9125
+    prefix: khan.
+    tags_prefix: ""
+    rate: 1

--- a/config/perf.yaml
+++ b/config/perf.yaml
@@ -8,3 +8,10 @@ postgres:
 jaeger:
   disabled: true
   samplingProbability: 0.001
+
+extensions:
+  dogstatsd:
+    host: localhost:8125
+    prefix: khan.
+    tags_prefix: ""
+    rate: 1

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -49,3 +49,10 @@ webhooks:
   statsPort: 9999
   runStats: false
   logToBuf: true
+
+extensions:
+  dogstatsd:
+    host: localhost:8125
+    prefix: khan.
+    tags_prefix: ""
+    rate: 1

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -19,6 +19,9 @@ Other than that, there are a couple more configurations you can pass using envir
 
 * `KHAN_NEWRELIC_KEY` - If you have a [New Relic](https://newrelic.com/) account, you can use this variable to specify your API Key to populate data with New Relic API;
 * `KHAN_SENTRY_URL` - If you have a [sentry server](https://docs.getsentry.com/hosted/) you can use this variable to specify your project's URL to send errors to.
+* `KHAN_EXTENSIONS_DOGSTATSD_HOST` - If you have a [statsd datadog daemon](https://docs.datadoghq.com/developers/dogstatsd/), Podium will publish metrics to the given host at a certain port. Ex. localhost:8125.
+* `KHAN_EXTENSIONS_DOGSTATSD_RATE` - If you have a [statsd daemon](https://docs.datadoghq.com/developers/dogstatsd/), Podium will export metrics to the deamon at the given rate.
+* `KHAN_EXTENSIONS_DOGSTATSD_TAGS_PREFIX` - If you have a [statsd daemon](https://docs.datadoghq.com/developers/dogstatsd/), you may set a prefix to every tag sent to the daemon.
 
 If you want to expose Khan outside your internal network it's advised to use Basic Authentication. You can specify basic authentication parameters with the following environment variables:
 

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -13,20 +13,20 @@ Khan uses PostgreSQL to store clans information. The container takes environment
 * `KHAN_POSTGRES_PORT` - PostgreSQL port to connect to;
 * `KHAN_POSTGRES_USER` - Password of the PostgreSQL Server to connect to;
 * `KHAN_POSTGRES_DBNAME` - Database name of the PostgreSQL Server to connect to;
-* `KHAN_POSTGRES_SSLMODE` - SSL Mode to connect to postgres with.
+* `KHAN_POSTGRES_SSLMODE` - SSL Mode to connect to postgres with;
 
 Other than that, there are a couple more configurations you can pass using environment variables:
 
 * `KHAN_NEWRELIC_KEY` - If you have a [New Relic](https://newrelic.com/) account, you can use this variable to specify your API Key to populate data with New Relic API;
-* `KHAN_SENTRY_URL` - If you have a [sentry server](https://docs.getsentry.com/hosted/) you can use this variable to specify your project's URL to send errors to.
-* `KHAN_EXTENSIONS_DOGSTATSD_HOST` - If you have a [statsd datadog daemon](https://docs.datadoghq.com/developers/dogstatsd/), Podium will publish metrics to the given host at a certain port. Ex. localhost:8125.
-* `KHAN_EXTENSIONS_DOGSTATSD_RATE` - If you have a [statsd daemon](https://docs.datadoghq.com/developers/dogstatsd/), Podium will export metrics to the deamon at the given rate.
-* `KHAN_EXTENSIONS_DOGSTATSD_TAGS_PREFIX` - If you have a [statsd daemon](https://docs.datadoghq.com/developers/dogstatsd/), you may set a prefix to every tag sent to the daemon.
+* `KHAN_SENTRY_URL` - If you have a [sentry server](https://docs.getsentry.com/hosted/) you can use this variable to specify your project's URL to send errors to;
+* `KHAN_EXTENSIONS_DOGSTATSD_HOST` - If you have a [statsd datadog daemon](https://docs.datadoghq.com/developers/dogstatsd/), Podium will publish metrics to the given host at a certain port. Ex. localhost:8125;
+* `KHAN_EXTENSIONS_DOGSTATSD_RATE` - If you have a [statsd daemon](https://docs.datadoghq.com/developers/dogstatsd/), Podium will export metrics to the deamon at the given rate;
+* `KHAN_EXTENSIONS_DOGSTATSD_TAGS_PREFIX` - If you have a [statsd daemon](https://docs.datadoghq.com/developers/dogstatsd/), you may set a prefix to every tag sent to the daemon;
 
 If you want to expose Khan outside your internal network it's advised to use Basic Authentication. You can specify basic authentication parameters with the following environment variables:
 
 * `KHAN_BASICAUTH_USERNAME` - If you specify this key, Khan will be configured to use basic auth with this user;
-* `KHAN_BASICAUTH_PASSWORD` - If you specify `BASICAUTH_USERNAME`, Khan will be configured to use basic auth with this password.
+* `KHAN_BASICAUTH_PASSWORD` - If you specify `BASICAUTH_USERNAME`, Khan will be configured to use basic auth with this password;
 
 ### Example command for running with Docker
 


### PR DESCRIPTION
This PR integrates Khan with DatadogStatsD and starts collecting the following metrics:

* latency (percentiles 50, 95 and 99) [metric khan.response_time_milliseconds]
* requests (per route and per status code) [metric khan.response_time_milliseconds_count]