### PR TITLE
Caching retrieveClansSummaries responses

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -784,6 +784,7 @@
     "github.com/Pallinder/go-randomdata",
     "github.com/bluele/factory-go/factory",
     "github.com/getsentry/raven-go",
+    "github.com/globalsign/mgo",
     "github.com/globalsign/mgo/bson",
     "github.com/go-gorp/gorp",
     "github.com/golang/mock/gomock",

--- a/api/app.go
+++ b/api/app.go
@@ -113,10 +113,10 @@ func (app *App) Configure() {
 	app.initESWorker()
 	app.initMongoWorker()
 	app.configureGoWorkers()
-	app.configureCache()
+	app.configureCaches()
 }
 
-func (app *App) configureCache() {
+func (app *App) configureCaches() {
 	// TTL
 	ttlKey := "cache.ttl"
 	app.Config.SetDefault(ttlKey, time.Minute)

--- a/api/app.go
+++ b/api/app.go
@@ -150,9 +150,9 @@ func (app *App) configureClansSummariesCache(defaultTTL, defaultCleanupInterval 
 	cleanupInterval := app.Config.GetDuration(cleanupIntervalKey)
 
 	app.clansSummariesCache = &caches.ClansSummaries{
-		Cache:                 gocache.New(ttl, cleanupInterval),
-		TimeToLive:            ttl,
-		TimeToLiveRandomError: ttlRandomError,
+		Cache:          gocache.New(ttl, cleanupInterval),
+		TTL:            ttl,
+		TTLRandomError: ttlRandomError,
 	}
 }
 

--- a/api/app.go
+++ b/api/app.go
@@ -74,7 +74,7 @@ type App struct {
 	DDStatsD       *extnethttpmiddleware.DogStatsD
 
 	cache               *gocache.Cache
-	clansSummariesCache *caches.ClansSummariesCache
+	clansSummariesCache *caches.ClansSummaries
 	db                  gorp.Database
 }
 
@@ -149,7 +149,7 @@ func (app *App) configureClansSummariesCache(defaultTTL, defaultCleanupInterval 
 	app.Config.SetDefault(cleanupIntervalKey, defaultCleanupInterval)
 	cleanupInterval := app.Config.GetDuration(cleanupIntervalKey)
 
-	app.clansSummariesCache = &caches.ClansSummariesCache{
+	app.clansSummariesCache = &caches.ClansSummaries{
 		Cache:                 gocache.New(ttl, cleanupInterval),
 		TimeToLive:            ttl,
 		TimeToLiveRandomError: ttlRandomError,

--- a/api/app.go
+++ b/api/app.go
@@ -128,6 +128,8 @@ func (app *App) configureCache() {
 	cleanupInterval := app.Config.GetDuration(cleanupIntervalKey)
 
 	app.cache = gocache.New(ttl, cleanupInterval)
+
+	// route caches
 	app.configureClansSummariesCache(ttl, cleanupInterval)
 }
 
@@ -137,12 +139,21 @@ func (app *App) configureClansSummariesCache(defaultTTL, defaultCleanupInterval 
 	app.Config.SetDefault(ttlKey, defaultTTL)
 	ttl := app.Config.GetDuration(ttlKey)
 
+	// TTL random error
+	ttlRandomErrorKey := "cache.clansSummaries.ttlRandomError"
+	app.Config.SetDefault(ttlRandomErrorKey, ttl/2)
+	ttlRandomError := app.Config.GetDuration(ttlRandomErrorKey)
+
 	// cleanup
 	cleanupIntervalKey := "cache.clansSummaries.cleanupInterval"
 	app.Config.SetDefault(cleanupIntervalKey, defaultCleanupInterval)
 	cleanupInterval := app.Config.GetDuration(cleanupIntervalKey)
 
-	app.clansSummariesCache = caches.NewClansSummariesCache(gocache.New(ttl, cleanupInterval))
+	app.clansSummariesCache = &caches.ClansSummariesCache{
+		Cache:                 gocache.New(ttl, cleanupInterval),
+		TimeToLive:            ttl,
+		TimeToLiveRandomError: ttlRandomError,
+	}
 }
 
 func (app *App) configureSentry() {

--- a/api/app.go
+++ b/api/app.go
@@ -126,6 +126,9 @@ func (app *App) configureGetGameCache() {
 	ttlKey := "caches.getGame.ttl"
 	app.Config.SetDefault(ttlKey, time.Minute)
 	ttl := app.Config.GetDuration(ttlKey)
+	if ttl <= 0 {
+		ttl = time.Minute
+	}
 
 	// cleanup
 	cleanupIntervalKey := "caches.getGame.cleanupInterval"
@@ -140,6 +143,9 @@ func (app *App) configureClansSummariesCache() {
 	ttlKey := "caches.clansSummaries.ttl"
 	app.Config.SetDefault(ttlKey, time.Minute)
 	ttl := app.Config.GetDuration(ttlKey)
+	if ttl <= 0 {
+		ttl = time.Minute
+	}
 
 	// cleanup
 	cleanupIntervalKey := "caches.clansSummaries.cleanupInterval"
@@ -148,7 +154,6 @@ func (app *App) configureClansSummariesCache() {
 
 	app.clansSummariesCache = &caches.ClansSummaries{
 		Cache: gocache.New(ttl, cleanupInterval),
-		TTL:   ttl,
 	}
 }
 

--- a/api/clan.go
+++ b/api/clan.go
@@ -1016,7 +1016,7 @@ func RetrieveClansSummariesHandler(app *App) func(c echo.Context) error {
 		var missingClans []string
 		err = WithSegment("clan-get-summaries", c, func() error {
 			log.D(l, "Retrieving clans summaries...")
-			clans, err = models.GetClansSummaries(
+			clans, err = app.clansSummariesCache.GetClansSummaries(
 				db,
 				gameID,
 				publicIDs,

--- a/caches/caches_suite_test.go
+++ b/caches/caches_suite_test.go
@@ -1,0 +1,13 @@
+package caches
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestApi(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Khan - Caches Suite")
+}

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -44,7 +44,8 @@ func (c *ClansSummaries) GetClansSummaries(db models.DB, gameID string, publicID
 	var err error
 	if len(missingPublicIDs) > 0 {
 		// fetch
-		clans, err := models.GetClansSummaries(db, gameID, missingPublicIDs)
+		var clans []map[string]interface{}
+		clans, err = models.GetClansSummaries(db, gameID, missingPublicIDs)
 		if err != nil {
 			if _, ok := err.(*models.CouldNotFindAllClansError); !ok {
 				return nil, err

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -9,8 +9,8 @@ import (
 	"github.com/topfreegames/khan/models"
 )
 
-// ClansSummariesCache represents a cache for the RetrieveClansSummaries operation
-type ClansSummariesCache struct {
+// ClansSummaries represents a cache for the RetrieveClansSummaries operation
+type ClansSummaries struct {
 	Cache                 *gocache.Cache
 	TimeToLive            time.Duration
 	TimeToLiveRandomError time.Duration
@@ -18,7 +18,7 @@ type ClansSummariesCache struct {
 
 // GetClansSummaries returns a summary of the clans details for a given list of clans by their game
 // id and public ids
-func (c *ClansSummariesCache) GetClansSummaries(db models.DB, gameID string, publicIDs []string) ([]map[string]interface{}, error) {
+func (c *ClansSummaries) GetClansSummaries(db models.DB, gameID string, publicIDs []string) ([]map[string]interface{}, error) {
 	resultMap := c.getCachedClansSummaries(gameID, publicIDs)
 	err := c.getAndCacheClansSummaries(db, gameID, resultMap)
 	if err != nil {
@@ -35,11 +35,11 @@ func (c *ClansSummariesCache) GetClansSummaries(db models.DB, gameID string, pub
 	return result, err
 }
 
-func (c *ClansSummariesCache) getClanSummaryCacheKey(gameID, publicID string) string {
+func (c *ClansSummaries) getClanSummaryCacheKey(gameID, publicID string) string {
 	return fmt.Sprintf("%s/%s", gameID, publicID)
 }
 
-func (c *ClansSummariesCache) getClanSummaryCache(gameID, publicID string) map[string]interface{} {
+func (c *ClansSummaries) getClanSummaryCache(gameID, publicID string) map[string]interface{} {
 	clan, present := c.Cache.Get(c.getClanSummaryCacheKey(gameID, publicID))
 	if !present {
 		return nil
@@ -47,13 +47,13 @@ func (c *ClansSummariesCache) getClanSummaryCache(gameID, publicID string) map[s
 	return clan.(map[string]interface{})
 }
 
-func (c *ClansSummariesCache) setClanSummaryCache(gameID, publicID string, clanPayload map[string]interface{}) {
+func (c *ClansSummaries) setClanSummaryCache(gameID, publicID string, clanPayload map[string]interface{}) {
 	ttl := c.TimeToLive - c.TimeToLiveRandomError
 	ttl += time.Duration(rand.Intn(int(2*c.TimeToLiveRandomError + 1)))
 	c.Cache.Set(c.getClanSummaryCacheKey(gameID, publicID), clanPayload, ttl)
 }
 
-func (c *ClansSummariesCache) getCachedClansSummaries(gameID string, publicIDs []string) map[string]map[string]interface{} {
+func (c *ClansSummaries) getCachedClansSummaries(gameID string, publicIDs []string) map[string]map[string]interface{} {
 	result := make(map[string]map[string]interface{})
 	for _, publicID := range publicIDs {
 		result[publicID] = c.getClanSummaryCache(gameID, publicID)
@@ -61,7 +61,7 @@ func (c *ClansSummariesCache) getCachedClansSummaries(gameID string, publicIDs [
 	return result
 }
 
-func (c *ClansSummariesCache) getAndCacheClansSummaries(db models.DB, gameID string, resultMap map[string]map[string]interface{}) error {
+func (c *ClansSummaries) getAndCacheClansSummaries(db models.DB, gameID string, resultMap map[string]map[string]interface{}) error {
 	missingPublicIDs := c.getMissingPublicIDsFromResultMap(resultMap)
 	if len(missingPublicIDs) == 0 {
 		return nil
@@ -80,7 +80,7 @@ func (c *ClansSummariesCache) getAndCacheClansSummaries(db models.DB, gameID str
 	return err
 }
 
-func (c *ClansSummariesCache) getMissingPublicIDsFromResultMap(resultMap map[string]map[string]interface{}) []string {
+func (c *ClansSummaries) getMissingPublicIDsFromResultMap(resultMap map[string]map[string]interface{}) []string {
 	var missingPublicIDs []string
 	for publicID, clanPayload := range resultMap {
 		if clanPayload == nil {

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -66,6 +66,7 @@ func (c *ClansSummaries) setClanSummaryCache(gameID, publicID string, clanPayloa
 	c.Cache.Set(c.getClanSummaryCacheKey(gameID, publicID), clanPayload, ttl)
 }
 
+// Return type map[string]map[string]interface{} maps public IDs to cached summaries.
 func (c *ClansSummaries) getCachedClansSummaries(gameID string, publicIDs []string) map[string]map[string]interface{} {
 	result := make(map[string]map[string]interface{})
 	for _, publicID := range publicIDs {

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -20,6 +20,7 @@ type ClansSummaries struct {
 }
 
 // GetClansSummaries is a cache in front of models.GetClansSummaries() with the exact same interface.
+// Like models.GetClansSummaries(), this function may return partial results + CouldNotFindAllClansError.
 // The map[string]interface{} return type represents a summary of one clan with the following keys/values:
 // "membershipCount":  int
 // "publicID":         string

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -1,0 +1,24 @@
+package caches
+
+import (
+	gocache "github.com/patrickmn/go-cache"
+	"github.com/topfreegames/khan/models"
+)
+
+// ClansSummariesCache represents a cache for the RetrieveClansSummaries operation
+type ClansSummariesCache struct {
+	cache *gocache.Cache
+}
+
+// NewClansSummariesCache returns a new instance of ClansSummariesCache
+func NewClansSummariesCache(cache *gocache.Cache) *ClansSummariesCache {
+	return &ClansSummariesCache{
+		cache: cache,
+	}
+}
+
+// GetClansSummaries returns a summary of the clans details for a given list of clans by their game
+// id and public ids
+func (c *ClansSummariesCache) GetClansSummaries(db models.DB, gameID string, publicIDs []string) ([]map[string]interface{}, error) {
+	return models.GetClansSummaries(db, gameID, publicIDs)
+}

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -1,6 +1,8 @@
 package caches
 
 import (
+	"fmt"
+
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/topfreegames/khan/models"
 )
@@ -20,5 +22,60 @@ func NewClansSummariesCache(cache *gocache.Cache) *ClansSummariesCache {
 // GetClansSummaries returns a summary of the clans details for a given list of clans by their game
 // id and public ids
 func (c *ClansSummariesCache) GetClansSummaries(db models.DB, gameID string, publicIDs []string) ([]map[string]interface{}, error) {
-	return models.GetClansSummaries(db, gameID, publicIDs)
+	resultMap := c.getCachedClansSummaries(gameID, publicIDs)
+	err := c.getAndCacheClansSummaries(db, gameID, resultMap)
+	var result []map[string]interface{}
+	for _, publicID := range publicIDs {
+		result = append(result, resultMap[publicID])
+	}
+	return result, err
+}
+
+func (c *ClansSummariesCache) getClanSummaryCacheKey(gameID, publicID string) string {
+	return fmt.Sprintf("%s/%s", gameID, publicID)
+}
+
+func (c *ClansSummariesCache) getClanSummaryCache(gameID, publicID string) map[string]interface{} {
+	clan, present := c.cache.Get(c.getClanSummaryCacheKey(gameID, publicID))
+	if !present {
+		return nil
+	}
+	return clan.(map[string]interface{})
+}
+
+func (c *ClansSummariesCache) setClanSummaryCache(gameID, publicID string, clanPayload map[string]interface{}) {
+	c.cache.Set(c.getClanSummaryCacheKey(gameID, publicID), clanPayload, gocache.DefaultExpiration)
+}
+
+func (c *ClansSummariesCache) getCachedClansSummaries(gameID string, publicIDs []string) map[string]map[string]interface{} {
+	result := make(map[string]map[string]interface{})
+	for _, publicID := range publicIDs {
+		result[publicID] = c.getClanSummaryCache(gameID, publicID)
+	}
+	return result
+}
+
+func (c *ClansSummariesCache) getAndCacheClansSummaries(db models.DB, gameID string, resultMap map[string]map[string]interface{}) error {
+	clans, err := models.GetClansSummaries(db, gameID, c.getMissingPublicIDsFromResultMap(resultMap))
+	if err != nil {
+		if _, ok := err.(*models.CouldNotFindAllClansError); !ok {
+			return err
+		}
+	}
+	for _, clanPayload := range clans {
+		publicID := clanPayload["publicID"].(string)
+		resultMap[publicID] = clanPayload
+		c.setClanSummaryCache(gameID, publicID, clanPayload)
+	}
+	return err
+}
+
+func (c *ClansSummariesCache) getMissingPublicIDsFromResultMap(resultMap map[string]map[string]interface{}) []string {
+	var missingPublicIDs []string
+	for publicID, clanPayload := range resultMap {
+		if clanPayload == nil {
+			missingPublicIDs = append(missingPublicIDs, publicID)
+		}
+	}
+	return missingPublicIDs
 }

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -19,8 +19,15 @@ type ClansSummaries struct {
 	TTLRandomError time.Duration
 }
 
-// GetClansSummaries returns a summary of the clans details for a given list of clans by their game
-// id and public ids
+// GetClansSummaries is a cache in front of models.GetClansSummaries() with the exact same interface.
+// The map[string]interface{} return type represents a summary of one clan with the following keys/values:
+// "membershipCount":  int
+// "publicID":         string
+// "metadata":         map[string]interface{} (user-defined arbitrary JSON object with clan metadata)
+// "name":             string
+// "allowApplication": bool
+// "autoJoin":         bool
+// TODO: replace this map with a richer type
 func (c *ClansSummaries) GetClansSummaries(db models.DB, gameID string, publicIDs []string) ([]map[string]interface{}, error) {
 	resultMap := c.getCachedClansSummaries(gameID, publicIDs)
 	err := c.getAndCacheClansSummaries(db, gameID, resultMap)
@@ -31,8 +38,8 @@ func (c *ClansSummaries) GetClansSummaries(db models.DB, gameID string, publicID
 	}
 	var result []map[string]interface{}
 	for _, publicID := range publicIDs {
-		if resultMap[publicID] != nil {
-			result = append(result, resultMap[publicID])
+		if summary := resultMap[publicID]; summary != nil {
+			result = append(result, summary)
 		}
 	}
 	return result, err

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -59,6 +59,9 @@ func (c *ClansSummaries) getClanSummaryCache(gameID, publicID string) map[string
 
 func (c *ClansSummaries) setClanSummaryCache(gameID, publicID string, clanPayload map[string]interface{}) {
 	ttl := c.TTL - c.TTLRandomError
+	if ttl < 0 {
+		ttl = 0
+	}
 	ttl += time.Duration(rand.Intn(int(2*c.TTLRandomError + 1)))
 	c.Cache.Set(c.getClanSummaryCacheKey(gameID, publicID), clanPayload, ttl)
 }

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -9,11 +9,14 @@ import (
 	"github.com/topfreegames/khan/models"
 )
 
-// ClansSummaries represents a cache for the RetrieveClansSummaries operation
+// ClansSummaries represents a cache for the RetrieveClansSummaries operation.
 type ClansSummaries struct {
-	Cache                 *gocache.Cache
-	TimeToLive            time.Duration
-	TimeToLiveRandomError time.Duration
+	// Cache points to an instance of gocache.Cache used as the backend cache object.
+	Cache *gocache.Cache
+
+	// The cache for one clan will live by a random amount of time within [TTL - TTLRandomError, TTL + TTLRandomError].
+	TTL            time.Duration
+	TTLRandomError time.Duration
 }
 
 // GetClansSummaries returns a summary of the clans details for a given list of clans by their game
@@ -48,8 +51,8 @@ func (c *ClansSummaries) getClanSummaryCache(gameID, publicID string) map[string
 }
 
 func (c *ClansSummaries) setClanSummaryCache(gameID, publicID string, clanPayload map[string]interface{}) {
-	ttl := c.TimeToLive - c.TimeToLiveRandomError
-	ttl += time.Duration(rand.Intn(int(2*c.TimeToLiveRandomError + 1)))
+	ttl := c.TTL - c.TTLRandomError
+	ttl += time.Duration(rand.Intn(int(2*c.TTLRandomError + 1)))
 	c.Cache.Set(c.getClanSummaryCacheKey(gameID, publicID), clanPayload, ttl)
 }
 

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -21,9 +21,16 @@ type ClansSummariesCache struct {
 func (c *ClansSummariesCache) GetClansSummaries(db models.DB, gameID string, publicIDs []string) ([]map[string]interface{}, error) {
 	resultMap := c.getCachedClansSummaries(gameID, publicIDs)
 	err := c.getAndCacheClansSummaries(db, gameID, resultMap)
+	if err != nil {
+		if _, ok := err.(*models.CouldNotFindAllClansError); !ok {
+			return nil, err
+		}
+	}
 	var result []map[string]interface{}
 	for _, publicID := range publicIDs {
-		result = append(result, resultMap[publicID])
+		if resultMap[publicID] != nil {
+			result = append(result, resultMap[publicID])
+		}
 	}
 	return result, err
 }

--- a/caches/clan.go
+++ b/caches/clan.go
@@ -22,7 +22,7 @@ type ClansSummaries struct {
 // "name":             string
 // "allowApplication": bool
 // "autoJoin":         bool
-// TODO: replace this map with a richer type
+// TODO(matheuscscp): replace this map with a richer type
 func (c *ClansSummaries) GetClansSummaries(db models.DB, gameID string, publicIDs []string) ([]map[string]interface{}, error) {
 	// first, assemble a result map with cached payloads. also assemble a missingPublicIDs string slice
 	idToPayload := make(map[string]map[string]interface{})

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -84,8 +84,7 @@ var _ = Describe("Clan Cache", func() {
 			}
 
 			cache := testing.GetTestClansSummariesCache()
-			cache.TTL = time.Second / 2
-			cache.TTLRandomError = 0
+			cache.TTL = time.Second / 4
 
 			// first call
 			clansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -65,12 +65,12 @@ var _ = Describe("Clan Cache", func() {
 			Expect(ok).To(BeTrue())
 			secondName, ok := secondPayload["name"].(string)
 			Expect(ok).To(BeTrue())
-			if !shouldBeChanged {
-				Expect(secondName).To(Equal(firstName))
-				Expect(secondName).NotTo(Equal(clans[0].Name))
-			} else {
+			if shouldBeChanged {
 				Expect(secondName).NotTo(Equal(firstName))
 				Expect(secondName).To(Equal(clans[0].Name))
+			} else {
+				Expect(secondName).To(Equal(firstName))
+				Expect(secondName).NotTo(Equal(clans[0].Name))
 			}
 		}
 

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -51,8 +51,7 @@ var _ = Describe("Clan Cache", func() {
 			}
 
 			// update a clan
-			const diffName = "different name"
-			clans[0].Name = diffName
+			clans[0].Name = "different name"
 			_, err = testDb.Update(clans[0])
 			Expect(err).NotTo(HaveOccurred())
 
@@ -105,8 +104,7 @@ var _ = Describe("Clan Cache", func() {
 			}
 
 			// update a clan
-			const diffName = "different name"
-			clans[0].Name = diffName
+			clans[0].Name = "different name"
 			_, err = testDb.Update(clans[0])
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(time.Second)

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -1,0 +1,130 @@
+package caches_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	uuid "github.com/satori/go.uuid"
+	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/testing"
+)
+
+var _ = Describe("Clan Cache", func() {
+	var testDb models.DB
+
+	BeforeEach(func() {
+		var err error
+		testDb, err = testing.GetTestDB()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("Clans Summaries", func() {
+		It("Should return a cached payload for a second call made immediately after the first", func() {
+			gameID := uuid.NewV4().String()
+			_, clans, err := models.GetTestClans(testDb, gameID, "test-sort-clan", 10)
+			Expect(err).NotTo(HaveOccurred())
+
+			var publicIDs []string
+			clansMap := make(map[string]int)
+			for i, clan := range clans {
+				publicIDs = append(publicIDs, clan.PublicID)
+				clansMap[clan.PublicID] = i + 1
+			}
+
+			cache := testing.GetTestClansSummariesCache()
+
+			// first call
+			clansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(clansSummaries)).To(Equal(len(clans)))
+			for _, clanPayload := range clansSummaries {
+				// assert public ID
+				publicID, ok := clanPayload["publicID"].(string)
+				Expect(ok).To(BeTrue())
+				Expect(clansMap[publicID]).To(BeNumerically(">", 0))
+
+				// assert name
+				name, ok := clanPayload["name"].(string)
+				Expect(ok).To(BeTrue())
+				Expect(name).To(Equal(clans[clansMap[publicID]-1].Name))
+			}
+
+			// update a clan
+			const diffName = "different name"
+			clans[0].Name = diffName
+			_, err = testDb.Update(clans[0])
+			Expect(err).NotTo(HaveOccurred())
+
+			// second call
+			secondClansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(secondClansSummaries)).To(Equal(len(clans)))
+			secondPayload := secondClansSummaries[0]
+			secondPublicID, ok := secondPayload["publicID"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(secondPublicID).To(Equal(clans[0].PublicID))
+			firstName, ok := clansSummaries[0]["name"].(string)
+			Expect(ok).To(BeTrue())
+			secondName, ok := secondPayload["name"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(secondName).To(Equal(firstName))
+			Expect(secondName).NotTo(Equal(clans[0].Name))
+		})
+
+		It("Should return fresh information after expiration time is reached", func() {
+			gameID := uuid.NewV4().String()
+			_, clans, err := models.GetTestClans(testDb, gameID, "test-sort-clan", 10)
+			Expect(err).NotTo(HaveOccurred())
+
+			var publicIDs []string
+			clansMap := make(map[string]int)
+			for i, clan := range clans {
+				publicIDs = append(publicIDs, clan.PublicID)
+				clansMap[clan.PublicID] = i + 1
+			}
+
+			cache := testing.GetTestClansSummariesCache()
+			cache.TimeToLive = time.Second / 2
+			cache.TimeToLiveRandomError = 0
+
+			// first call
+			clansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(clansSummaries)).To(Equal(len(clans)))
+			for _, clanPayload := range clansSummaries {
+				// assert public ID
+				publicID, ok := clanPayload["publicID"].(string)
+				Expect(ok).To(BeTrue())
+				Expect(clansMap[publicID]).To(BeNumerically(">", 0))
+
+				// assert name
+				name, ok := clanPayload["name"].(string)
+				Expect(ok).To(BeTrue())
+				Expect(name).To(Equal(clans[clansMap[publicID]-1].Name))
+			}
+
+			// update a clan
+			const diffName = "different name"
+			clans[0].Name = diffName
+			_, err = testDb.Update(clans[0])
+			Expect(err).NotTo(HaveOccurred())
+			time.Sleep(time.Second)
+
+			// second call
+			secondClansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(secondClansSummaries)).To(Equal(len(clans)))
+			secondPayload := secondClansSummaries[0]
+			secondPublicID, ok := secondPayload["publicID"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(secondPublicID).To(Equal(clans[0].PublicID))
+			firstName, ok := clansSummaries[0]["name"].(string)
+			Expect(ok).To(BeTrue())
+			secondName, ok := secondPayload["name"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(secondName).NotTo(Equal(firstName))
+			Expect(secondName).To(Equal(clans[0].Name))
+		})
+	})
+})

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -85,8 +85,8 @@ var _ = Describe("Clan Cache", func() {
 			}
 
 			cache := testing.GetTestClansSummariesCache()
-			cache.TimeToLive = time.Second / 2
-			cache.TimeToLiveRandomError = 0
+			cache.TTL = time.Second / 2
+			cache.TTLRandomError = 0
 
 			// first call
 			clansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -20,55 +20,81 @@ var _ = Describe("Clan Cache", func() {
 	})
 
 	Describe("Clans Summaries", func() {
+		getPublicIDsAndIDToIndexMap := func(clans []*models.Clan) ([]string, map[string]int) {
+			var publicIDs []string
+			idToIdx := make(map[string]int)
+			for i, clan := range clans {
+				publicIDs = append(publicIDs, clan.PublicID)
+				idToIdx[clan.PublicID] = i + 1
+			}
+			return publicIDs, idToIdx
+		}
+
+		assertFirstCacheCall := func(clans []*models.Clan, idToIdx map[string]int, clansSummaries []map[string]interface{}) {
+			Expect(len(clansSummaries)).To(Equal(len(clans)))
+			for _, clanPayload := range clansSummaries {
+				// assert public ID
+				publicID, ok := clanPayload["publicID"].(string)
+				Expect(ok).To(BeTrue())
+				Expect(idToIdx[publicID]).To(BeNumerically(">", 0))
+
+				// assert name
+				name, ok := clanPayload["name"].(string)
+				Expect(ok).To(BeTrue())
+				Expect(name).To(Equal(clans[idToIdx[publicID]-1].Name))
+			}
+		}
+
+		updateClan := func(db models.DB, clan *models.Clan) {
+			clan.Name = "different name"
+			_, err := db.Update(clan)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		assertSecondCacheCall := func(clans []*models.Clan, clansSummaries, secondClansSummaries []map[string]interface{}, shouldBeChanged bool) {
+			Expect(len(secondClansSummaries)).To(Equal(len(clans)))
+
+			// assert public ID
+			secondPayload := secondClansSummaries[0]
+			secondPublicID, ok := secondPayload["publicID"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(secondPublicID).To(Equal(clans[0].PublicID))
+
+			// assert name
+			firstName, ok := clansSummaries[0]["name"].(string)
+			Expect(ok).To(BeTrue())
+			secondName, ok := secondPayload["name"].(string)
+			Expect(ok).To(BeTrue())
+			if !shouldBeChanged {
+				Expect(secondName).To(Equal(firstName))
+				Expect(secondName).NotTo(Equal(clans[0].Name))
+			} else {
+				Expect(secondName).NotTo(Equal(firstName))
+				Expect(secondName).To(Equal(clans[0].Name))
+			}
+		}
+
 		It("Should return a cached payload for a second call made immediately after the first", func() {
 			gameID := uuid.NewV4().String()
 			_, clans, err := models.GetTestClans(testDb, gameID, "test-sort-clan", 10)
 			Expect(err).NotTo(HaveOccurred())
 
-			var publicIDs []string
-			clansMap := make(map[string]int)
-			for i, clan := range clans {
-				publicIDs = append(publicIDs, clan.PublicID)
-				clansMap[clan.PublicID] = i + 1
-			}
+			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)
 
 			cache := testing.GetTestClansSummariesCache()
 
 			// first call
 			clansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(clansSummaries)).To(Equal(len(clans)))
-			for _, clanPayload := range clansSummaries {
-				// assert public ID
-				publicID, ok := clanPayload["publicID"].(string)
-				Expect(ok).To(BeTrue())
-				Expect(clansMap[publicID]).To(BeNumerically(">", 0))
-
-				// assert name
-				name, ok := clanPayload["name"].(string)
-				Expect(ok).To(BeTrue())
-				Expect(name).To(Equal(clans[clansMap[publicID]-1].Name))
-			}
+			assertFirstCacheCall(clans, idToIdx, clansSummaries)
 
 			// update a clan
-			clans[0].Name = "different name"
-			_, err = testDb.Update(clans[0])
-			Expect(err).NotTo(HaveOccurred())
+			updateClan(testDb, clans[0])
 
 			// second call
 			secondClansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(secondClansSummaries)).To(Equal(len(clans)))
-			secondPayload := secondClansSummaries[0]
-			secondPublicID, ok := secondPayload["publicID"].(string)
-			Expect(ok).To(BeTrue())
-			Expect(secondPublicID).To(Equal(clans[0].PublicID))
-			firstName, ok := clansSummaries[0]["name"].(string)
-			Expect(ok).To(BeTrue())
-			secondName, ok := secondPayload["name"].(string)
-			Expect(ok).To(BeTrue())
-			Expect(secondName).To(Equal(firstName))
-			Expect(secondName).NotTo(Equal(clans[0].Name))
+			assertSecondCacheCall(clans, clansSummaries, secondClansSummaries, false)
 		})
 
 		It("Should return fresh information after expiration time is reached", func() {
@@ -76,12 +102,7 @@ var _ = Describe("Clan Cache", func() {
 			_, clans, err := models.GetTestClans(testDb, gameID, "test-sort-clan", 10)
 			Expect(err).NotTo(HaveOccurred())
 
-			var publicIDs []string
-			clansMap := make(map[string]int)
-			for i, clan := range clans {
-				publicIDs = append(publicIDs, clan.PublicID)
-				clansMap[clan.PublicID] = i + 1
-			}
+			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)
 
 			cache := testing.GetTestClansSummariesCache()
 			cache.TTL = time.Second / 4
@@ -89,39 +110,16 @@ var _ = Describe("Clan Cache", func() {
 			// first call
 			clansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(clansSummaries)).To(Equal(len(clans)))
-			for _, clanPayload := range clansSummaries {
-				// assert public ID
-				publicID, ok := clanPayload["publicID"].(string)
-				Expect(ok).To(BeTrue())
-				Expect(clansMap[publicID]).To(BeNumerically(">", 0))
-
-				// assert name
-				name, ok := clanPayload["name"].(string)
-				Expect(ok).To(BeTrue())
-				Expect(name).To(Equal(clans[clansMap[publicID]-1].Name))
-			}
+			assertFirstCacheCall(clans, idToIdx, clansSummaries)
 
 			// update a clan
-			clans[0].Name = "different name"
-			_, err = testDb.Update(clans[0])
-			Expect(err).NotTo(HaveOccurred())
+			updateClan(testDb, clans[0])
 			time.Sleep(time.Second)
 
 			// second call
 			secondClansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(secondClansSummaries)).To(Equal(len(clans)))
-			secondPayload := secondClansSummaries[0]
-			secondPublicID, ok := secondPayload["publicID"].(string)
-			Expect(ok).To(BeTrue())
-			Expect(secondPublicID).To(Equal(clans[0].PublicID))
-			firstName, ok := clansSummaries[0]["name"].(string)
-			Expect(ok).To(BeTrue())
-			secondName, ok := secondPayload["name"].(string)
-			Expect(ok).To(BeTrue())
-			Expect(secondName).NotTo(Equal(firstName))
-			Expect(secondName).To(Equal(clans[0].Name))
+			assertSecondCacheCall(clans, clansSummaries, secondClansSummaries, true)
 		})
 	})
 })

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Clan Cache", func() {
 
 			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)
 
-			cache := testing.GetTestClansSummariesCache()
+			cache := testing.GetTestClansSummariesCache(time.Minute, time.Minute)
 
 			// first call
 			clansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
@@ -104,8 +104,7 @@ var _ = Describe("Clan Cache", func() {
 
 			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)
 
-			cache := testing.GetTestClansSummariesCache()
-			cache.TTL = time.Second / 4
+			cache := testing.GetTestClansSummariesCache(time.Second/4, time.Minute)
 
 			// first call
 			clansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)
@@ -114,7 +113,7 @@ var _ = Describe("Clan Cache", func() {
 
 			// update a clan
 			updateClan(testDb, clans[0])
-			time.Sleep(time.Second)
+			time.Sleep(time.Second / 2)
 
 			// second call
 			secondClansSummaries, err := cache.GetClansSummaries(testDb, gameID, publicIDs)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -61,10 +61,10 @@ extensions:
     tags_prefix: ""
     rate: 1
 
-cache:
-  ttl: 1m
-  cleanupInterval: 1m
+caches:
+  getGame:
+    ttl: 1m
+    cleanupInterval: 1m
   clansSummaries:
     ttl: 1m
-    ttlRandomError: 30s
     cleanupInterval: 1m

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -64,3 +64,7 @@ extensions:
 cache:
   ttl: 1m
   cleanupInterval: 1m
+  clansSummaries:
+    ttl: 1m
+    ttlRandomError: 30s
+    cleanupInterval: 1m

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -86,10 +86,10 @@ loadtest:
     retrieveClansSummaries:
       probability: 1
 
-cache:
-  ttl: 1m
-  cleanupInterval: 1m
+caches:
+  getGame:
+    ttl: 1m
+    cleanupInterval: 1m
   clansSummaries:
     ttl: 1m
-    ttlRandomError: 30s
     cleanupInterval: 1m

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -89,3 +89,7 @@ loadtest:
 cache:
   ttl: 1m
   cleanupInterval: 1m
+  clansSummaries:
+    ttl: 1m
+    ttlRandomError: 30s
+    cleanupInterval: 1m

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -36,7 +36,14 @@ func CreateClanNameTextIndexInMongo(getTestMongo func() (interfaces.MongoDB, err
 
 // GetTestDB returns a connection to the test database.
 func GetTestDB() (models.DB, error) {
-	return models.GetDB("localhost", "khan_test", 5433, "disable", "khan_test", "")
+	return models.GetDB(
+		"localhost", // host
+		"khan_test", // user
+		5433,        // port
+		"disable",   // sslMode
+		"khan_test", // dbName
+		"",          // password
+	)
 }
 
 // GetTestClansSummariesCache returns a test cache for clans summaries.

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -34,12 +34,12 @@ func CreateClanNameTextIndexInMongo(getTestMongo func() (interfaces.MongoDB, err
 	return mongo.Run(cmd, nil)
 }
 
-// GetTestDB returns a connection to the test database
+// GetTestDB returns a connection to the test database.
 func GetTestDB() (models.DB, error) {
 	return models.GetDB("localhost", "khan_test", 5433, "disable", "khan_test", "")
 }
 
-// GetTestClansSummariesCache returns a test cache for clans summaries
+// GetTestClansSummariesCache returns a test cache for clans summaries.
 func GetTestClansSummariesCache() *caches.ClansSummaries {
 	return &caches.ClansSummaries{
 		Cache:          gocache.New(time.Minute, time.Minute),

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -49,8 +49,7 @@ func GetTestDB() (models.DB, error) {
 // GetTestClansSummariesCache returns a test cache for clans summaries.
 func GetTestClansSummariesCache() *caches.ClansSummaries {
 	return &caches.ClansSummaries{
-		Cache:          gocache.New(time.Minute, time.Minute),
-		TTL:            time.Minute,
-		TTLRandomError: time.Minute / 2,
+		Cache: gocache.New(time.Minute, time.Minute),
+		TTL:   time.Minute,
 	}
 }

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -42,8 +42,8 @@ func GetTestDB() (models.DB, error) {
 // GetTestClansSummariesCache returns a test cache for clans summaries
 func GetTestClansSummariesCache() *caches.ClansSummaries {
 	return &caches.ClansSummaries{
-		Cache:                 gocache.New(time.Minute, time.Minute),
-		TimeToLive:            time.Minute,
-		TimeToLiveRandomError: time.Minute / 2,
+		Cache:          gocache.New(time.Minute, time.Minute),
+		TTL:            time.Minute,
+		TTLRandomError: time.Minute / 2,
 	}
 }

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -40,8 +40,8 @@ func GetTestDB() (models.DB, error) {
 }
 
 // GetTestClansSummariesCache returns a test cache for clans summaries
-func GetTestClansSummariesCache() *caches.ClansSummariesCache {
-	return &caches.ClansSummariesCache{
+func GetTestClansSummariesCache() *caches.ClansSummaries {
+	return &caches.ClansSummaries{
 		Cache:                 gocache.New(time.Minute, time.Minute),
 		TimeToLive:            time.Minute,
 		TimeToLiveRandomError: time.Minute / 2,

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -47,9 +47,8 @@ func GetTestDB() (models.DB, error) {
 }
 
 // GetTestClansSummariesCache returns a test cache for clans summaries.
-func GetTestClansSummariesCache() *caches.ClansSummaries {
+func GetTestClansSummariesCache(ttl, cleanupInterval time.Duration) *caches.ClansSummaries {
 	return &caches.ClansSummaries{
-		Cache: gocache.New(time.Minute, time.Minute),
-		TTL:   time.Minute,
+		Cache: gocache.New(ttl, cleanupInterval),
 	}
 }

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -2,9 +2,14 @@ package testing
 
 import (
 	"fmt"
+	"time"
+
+	"github.com/topfreegames/khan/caches"
 
 	"github.com/globalsign/mgo/bson"
+	gocache "github.com/patrickmn/go-cache"
 	"github.com/topfreegames/extensions/mongo/interfaces"
+	"github.com/topfreegames/khan/models"
 )
 
 // CreateClanNameTextIndexInMongo creates the necessary text index for clan search in mongo
@@ -27,4 +32,18 @@ func CreateClanNameTextIndexInMongo(getTestMongo func() (interfaces.MongoDB, err
 		}},
 	}
 	return mongo.Run(cmd, nil)
+}
+
+// GetTestDB returns a connection to the test database
+func GetTestDB() (models.DB, error) {
+	return models.GetDB("localhost", "khan_test", 5433, "disable", "khan_test", "")
+}
+
+// GetTestClansSummariesCache returns a test cache for clans summaries
+func GetTestClansSummariesCache() *caches.ClansSummariesCache {
+	return &caches.ClansSummariesCache{
+		Cache:                 gocache.New(time.Minute, time.Minute),
+		TimeToLive:            time.Minute,
+		TimeToLiveRandomError: time.Minute / 2,
+	}
 }


### PR DESCRIPTION
Problem: retrieveClansSummaries fetches a lot of data for many clans in most use cases (clan rankings). On a load test we detected that database CPU usage reaches 100% with a small load (compared to the load we expect for the launch of our next game).

Solution: Cache clans summaries individually, because players are used to rankings with information a little bit delayed.