### PR TITLE
Change GetClanDetailsQuery

### DIFF
--- a/models/clan.go
+++ b/models/clan.go
@@ -805,7 +805,7 @@ func GetClanDetails(db DB, gameID string, clan *Clan, maxClansPerPlayer int, opt
 			UNION ALL (
 				SELECT *
 				FROM memberships im
-				WHERE im.clan_id=$2 AND im.deleted_at=0 AND im.approved=false AND im.denied=false AND im.banned=false AND (im.requestor_id>im.player_id OR im.requestor_id<im.player)
+				WHERE im.clan_id=$2 AND im.deleted_at=0 AND im.approved=false AND im.denied=false AND im.banned=false AND (im.requestor_id>im.player_id OR im.requestor_id<im.player_id)
 				ORDER BY im.id %s
 				LIMIT $4
 			)

--- a/models/clan.go
+++ b/models/clan.go
@@ -805,7 +805,7 @@ func GetClanDetails(db DB, gameID string, clan *Clan, maxClansPerPlayer int, opt
 			UNION ALL (
 				SELECT *
 				FROM memberships im
-				WHERE im.clan_id=$2 AND im.deleted_at=0 AND im.approved=false AND im.denied=false AND im.banned=false AND im.requestor_id<>im.player_id
+				WHERE im.clan_id=$2 AND im.deleted_at=0 AND im.approved=false AND im.denied=false AND im.banned=false AND (im.requestor_id>im.player_id OR im.requestor_id<im.player)
 				ORDER BY im.id %s
 				LIMIT $4
 			)

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -2,12 +2,14 @@ version: '2'
 
 services:
   postgres:
+    container_name: khan_postgres_1
     image: postgres:9.5
     ports:
       - "5433:5432"
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
   elasticsearch:
+    container_name: khan_elasticsearch_1
     image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
     ports:
       - "9200:9200"
@@ -16,10 +18,12 @@ services:
       - transport.host=127.0.0.1
       - xpack.security.enabled=false
   redis:
+    container_name: khan_redis_1
     image: redis
     ports:
       - "50505:6379"
   mongo:
+    container_name: khan_mongo_1
     image: mongo
     ports:
       - "27017:27017"

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: postgres:9.5
     ports:
       - "5433:5432"
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
     ports:


### PR DESCRIPTION
This very little change in the query has a huge impact on performance in postgresql as seen below. The reason is that the comparison using `<` and `>` can better use the index and the comparison using `<>` needs to do a full index scan.

This is the `QUERY PLAN` executed using `EXPLAIN ANALYZE` on production DB before the change:
<img width="1441" alt="Screen Shot 2020-06-03 at 17 52 49" src="https://user-images.githubusercontent.com/11096408/83690624-6f251e80-a5c7-11ea-8c33-7ee767de5c10.png">

As you can see in the image the execution time takes almost 2s because on step `Subquery Scan "SELECT* 2"` it needs to do a scan to find the matches and the table has 3534350 entries.

This is  the `QUERY PLAN` after the change:
<img width="1420" alt="Screen Shot 2020-06-03 at 17 54 47" src="https://user-images.githubusercontent.com/11096408/83710062-33557d80-a5f6-11ea-9052-91ed2f602555.png">

Now the execution time is 32ms because it doesn't need to do a full index scan and for this example it runs more than 20 times faster.