### PR TITLE
Explicit database creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,15 +155,19 @@ drop:
 db migrate:
 	@go run main.go migrate -c ./config/local.yaml
 
-db-test migrate-test:
+db-test migrate-test: create-test-db
 	@go run main.go migrate -c ./config/test.yaml
 	@go run main.go migrate -t 0 -c ./config/test.yaml
 	@go run main.go migrate -c ./config/test.yaml
 
+create-test-db:
+	@psql -d postgres -h localhost -p 5433 -U postgres -f db/create-test.sql > /dev/null
+	@echo "Test database created successfully!"
+
 drop-test:
 	@-psql -d postgres -h localhost -p 5433 -U postgres -c "SELECT pg_terminate_backend(pid.pid) FROM pg_stat_activity, (SELECT pid FROM pg_stat_activity where pid <> pg_backend_pid()) pid WHERE datname='khan_test';"
 	@psql -d postgres -h localhost -p 5433 -U postgres -f db/drop-test.sql > /dev/null
-	@echo "Test database created successfully!"
+	@echo "Test database dropped successfully!"
 
 run-test-khan: build
 	@rm -rf /tmp/khan-bench.log
@@ -185,6 +189,10 @@ restore-perf:
 
 dump-perf:
 	@pg_dump khan_perf > khan-perf.dump
+
+create-perf-db:
+	@psql -d postgres -h localhost -p 5433 -U postgres -f db/create-perf.sql > /dev/null
+	@echo "Perf database created successfully!"
 
 drop-perf:
 	@psql -d postgres -h localhost -p 5433 -U postgres -f db/drop-perf.sql > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ run-prune-docker:
 
 test: start-test-deps run-test
 
-start-test-deps: schema-update start-deps assets drop-test db-test
+start-test-deps: schema-update start-deps assets drop-test criate-test-db migrate-test
 
 run-test:
 	@SKIP_ELASTIC_LOG=true ginkgo -nodes=1 -r --cover .
@@ -150,12 +150,12 @@ random-data:
 
 drop:
 	@psql -d postgres -U postgres -p 5433 -h ${MYIP} -f db/drop.sql > /dev/null
-	@echo "Database created successfully!"
+	@echo "Database dropped successfully!"
 
 db migrate:
 	@go run main.go migrate -c ./config/local.yaml
 
-db-test migrate-test: create-test-db
+db-test migrate-test:
 	@go run main.go migrate -c ./config/test.yaml
 	@go run main.go migrate -t 0 -c ./config/test.yaml
 	@go run main.go migrate -c ./config/test.yaml

--- a/db/create-perf.sql
+++ b/db/create-perf.sql
@@ -1,0 +1,17 @@
+-- khan
+-- https://github.com/topfreegames/khan
+--
+-- Licensed under the MIT license:
+-- http://www.opensource.org/licenses/mit-license
+-- Copyright © 2016 Top Free Games <backend@tfgco.com>
+
+CREATE ROLE khan_perf LOGIN
+  SUPERUSER INHERIT CREATEDB CREATEROLE;
+
+CREATE DATABASE khan_perf
+  WITH OWNER = khan_perf
+       ENCODING = 'UTF8'
+       TABLESPACE = pg_default
+       TEMPLATE = template0;
+
+GRANT ALL ON SCHEMA public TO khan_perf;

--- a/db/create-test.sql
+++ b/db/create-test.sql
@@ -1,0 +1,17 @@
+-- khan
+-- https://github.com/topfreegames/khan
+--
+-- Licensed under the MIT license:
+-- http://www.opensource.org/licenses/mit-license
+-- Copyright © 2016 Top Free Games <backend@tfgco.com>
+
+CREATE ROLE khan_test LOGIN
+  SUPERUSER INHERIT CREATEDB CREATEROLE;
+
+CREATE DATABASE khan_test
+  WITH OWNER = khan_test
+       ENCODING = 'UTF8'
+       TABLESPACE = pg_default
+       TEMPLATE = template0;
+
+GRANT ALL ON SCHEMA public TO khan_test;

--- a/db/drop-perf.sql
+++ b/db/drop-perf.sql
@@ -8,14 +8,3 @@
 REVOKE ALL ON SCHEMA public FROM khan_perf;
 DROP DATABASE IF EXISTS khan_perf;
 DROP ROLE khan_perf;
-
-CREATE ROLE khan_perf LOGIN
-  SUPERUSER INHERIT CREATEDB CREATEROLE;
-
-CREATE DATABASE khan_perf
-  WITH OWNER = khan_perf
-       ENCODING = 'UTF8'
-       TABLESPACE = pg_default
-       TEMPLATE = template0;
-
-GRANT ALL ON SCHEMA public TO khan_perf;

--- a/db/drop-test.sql
+++ b/db/drop-test.sql
@@ -8,14 +8,3 @@
 REVOKE ALL ON SCHEMA public FROM khan_test;
 DROP DATABASE IF EXISTS khan_test;
 DROP ROLE khan_test;
-
-CREATE ROLE khan_test LOGIN
-  SUPERUSER INHERIT CREATEDB CREATEROLE;
-
-CREATE DATABASE khan_test
-  WITH OWNER = khan_test
-       ENCODING = 'UTF8'
-       TABLESPACE = pg_default
-       TEMPLATE = template0;
-
-GRANT ALL ON SCHEMA public TO khan_test;


### PR DESCRIPTION
WHY
=======
The database and database role creation is done inside the command `drop-test` on the Makefile. This PR proposes to create a command to explicit this.

WHAT WAS DONE
=======
* Create commands `criate-test-db` and `create-perf-db`
* Separete `drop-test.sql` into `drop-test.sql` and `create-test.sql`
* Separete `drop-perf.sql` into `drop-perf.sql` and `create-perf.sql`