### PR TITLE
Implement secure on read routes

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -71,6 +71,7 @@ type App struct {
 	Fast           bool
 	NewRelic       newrelic.Application
 	DDStatsD       *extnethttpmiddleware.DogStatsD
+	EncryptionKey  []byte
 
 	getGameCache        *gocache.Cache
 	clansSummariesCache *caches.ClansSummaries
@@ -289,6 +290,7 @@ func (app *App) setConfigurationDefaults() {
 	app.Config.SetDefault("khan.defaultCooldownBeforeApply", -1)
 	app.Config.SetDefault("jaeger.disabled", true)
 	app.Config.SetDefault("jaeger.samplingProbability", 0.001)
+	app.Config.SetDefault("security.encryptionKey", "00000000000000000000000000000000")
 
 	app.setHandlersConfigurationDefaults()
 
@@ -323,6 +325,8 @@ func (app *App) loadConfiguration() {
 	} else {
 		log.P(l, "Config file failed to load.")
 	}
+
+	app.EncryptionKey = []byte(app.Config.GetString("security.encryptionKey"))
 }
 
 func (app *App) connectDatabase() {

--- a/api/clan.go
+++ b/api/clan.go
@@ -381,6 +381,7 @@ func LeaveClanHandler(app *App) func(c echo.Context) error {
 				log.D(l, "Leaving clan...")
 				clan, previousOwner, newOwner, err = models.LeaveClan(
 					tx,
+					app.EncryptionKey,
 					gameID,
 					publicID,
 				)
@@ -538,6 +539,7 @@ func TransferOwnershipHandler(app *App) func(c echo.Context) error {
 				log.D(l, "Transferring clan ownership...")
 				clan, previousOwner, newOwner, err = models.TransferClanOwnership(
 					tx,
+					app.EncryptionKey,
 					gameID,
 					publicID,
 					payload.PlayerPublicID,

--- a/api/clan.go
+++ b/api/clan.go
@@ -431,7 +431,7 @@ func LeaveClanHandler(app *App) func(c echo.Context) error {
 		fields := []zap.Field{}
 
 		WithSegment("response-serialize", c, func() error {
-			pOwnerJSON := previousOwner.Serialize()
+			pOwnerJSON := previousOwner.Serialize(app.EncryptionKey)
 			delete(pOwnerJSON, "gameID")
 
 			res["previousOwner"] = pOwnerJSON
@@ -439,7 +439,7 @@ func LeaveClanHandler(app *App) func(c echo.Context) error {
 			res["isDeleted"] = true
 
 			if newOwner != nil {
-				nOwnerJSON := newOwner.Serialize()
+				nOwnerJSON := newOwner.Serialize(app.EncryptionKey)
 				delete(nOwnerJSON, "gameID")
 				res["newOwner"] = nOwnerJSON
 				res["isDeleted"] = false
@@ -587,10 +587,10 @@ func TransferOwnershipHandler(app *App) func(c echo.Context) error {
 
 		var pOwnerJSON, nOwnerJSON map[string]interface{}
 		err = WithSegment("response-serialize", c, func() error {
-			pOwnerJSON = previousOwner.Serialize()
+			pOwnerJSON = previousOwner.Serialize(app.EncryptionKey)
 			delete(pOwnerJSON, "gameID")
 
-			nOwnerJSON = newOwner.Serialize()
+			nOwnerJSON = newOwner.Serialize(app.EncryptionKey)
 			delete(nOwnerJSON, "gameID")
 
 			return nil
@@ -845,6 +845,7 @@ func RetrieveClanHandler(app *App) func(c echo.Context) error {
 			log.D(l, "Retrieving clan details...")
 			clanResult, err = models.GetClanDetails(
 				db,
+				app.EncryptionKey,
 				gameID,
 				clan,
 				game.MaxClansPerPlayer,

--- a/api/clan.go
+++ b/api/clan.go
@@ -126,6 +126,7 @@ func CreateClanHandler(app *App) func(c echo.Context) error {
 			log.D(l, "Creating clan...")
 			clan, err = models.CreateClan(
 				tx,
+				app.EncryptionKey,
 				gameID,
 				payload.PublicID,
 				payload.Name,

--- a/api/clan_helpers.go
+++ b/api/clan_helpers.go
@@ -31,7 +31,7 @@ func dispatchClanOwnershipChangeHook(app *App, hookType int, clan *models.Clan, 
 		zap.String("previousOwnerPublicID", previousOwner.PublicID),
 	)
 
-	previousOwnerJSON := previousOwner.Serialize()
+	previousOwnerJSON := previousOwner.Serialize(app.EncryptionKey)
 	delete(previousOwnerJSON, "gameID")
 
 	clanJSON := clan.Serialize()
@@ -46,7 +46,7 @@ func dispatchClanOwnershipChangeHook(app *App, hookType int, clan *models.Clan, 
 	}
 
 	if newOwner != nil {
-		newOwnerJSON := newOwner.Serialize()
+		newOwnerJSON := newOwner.Serialize(app.EncryptionKey)
 		delete(newOwnerJSON, "gameID")
 		result["newOwner"] = newOwnerJSON
 		result["isDeleted"] = false

--- a/api/membership.go
+++ b/api/membership.go
@@ -87,6 +87,7 @@ func ApplyForMembershipHandler(app *App) func(c echo.Context) error {
 				log.D(l, "Applying for membership...")
 				membership, err = models.CreateMembership(
 					tx,
+					app.EncryptionKey,
 					game,
 					gameID,
 					payload.Level,
@@ -221,6 +222,7 @@ func InviteForMembershipHandler(app *App) func(c echo.Context) error {
 				log.D(l, "Inviting for membership...")
 				membership, err = models.CreateMembership(
 					tx,
+					app.EncryptionKey,
 					game,
 					gameID,
 					payload.Level,
@@ -354,6 +356,7 @@ func ApproveOrDenyMembershipApplicationHandler(app *App) func(c echo.Context) er
 				var mErr error
 				membership, mErr = models.ApproveOrDenyMembershipApplication(
 					tx,
+					app.EncryptionKey,
 					game,
 					gameID,
 					payload.PlayerPublicID,
@@ -507,6 +510,7 @@ func ApproveOrDenyMembershipInvitationHandler(app *App) func(c echo.Context) err
 				log.D(l, "Approving/Denying membership invitation...")
 				membership, err = models.ApproveOrDenyMembershipInvitation(
 					tx,
+					app.EncryptionKey,
 					game,
 					gameID,
 					payload.PlayerPublicID,

--- a/api/membership.go
+++ b/api/membership.go
@@ -383,7 +383,7 @@ func ApproveOrDenyMembershipApplicationHandler(app *App) func(c echo.Context) er
 			return WithSegment("player-retrieve", c, func() error {
 				log.D(l, "Retrieving requestor details.")
 				var gErr error
-				requestor, gErr = models.GetPlayerByPublicID(tx, gameID, payload.RequestorPublicID)
+				requestor, gErr = models.GetPlayerByPublicID(tx, app.EncryptionKey, gameID, payload.RequestorPublicID)
 				if gErr != nil {
 					msg := "Requestor details retrieval failed."
 					txErr := rb(gErr)
@@ -756,7 +756,7 @@ func PromoteOrDemoteMembershipHandler(app *App, action string) func(c echo.Conte
 
 			err = WithSegment("player-retrieve", c, func() error {
 				log.D(l, "Retrieving promoter/demoter member...")
-				requestor, err = models.GetPlayerByPublicID(db, membership.GameID, payload.RequestorPublicID)
+				requestor, err = models.GetPlayerByPublicID(db, app.EncryptionKey, membership.GameID, payload.RequestorPublicID)
 				if err != nil {
 					log.E(l, "Promoter/Demoter member retrieval failed.", func(cm log.CM) {
 						cm.Write(zap.Error(err))

--- a/api/membership_helpers.go
+++ b/api/membership_helpers.go
@@ -125,11 +125,11 @@ func dispatchMembershipHook(app *App, db models.DB, hookType int, gameID string,
 	clanJSON := clan.Serialize()
 	delete(clanJSON, "gameID")
 
-	playerJSON := player.Serialize()
+	playerJSON := player.Serialize(app.EncryptionKey)
 	playerJSON["membershipLevel"] = membershipLevel
 	delete(playerJSON, "gameID")
 
-	requestorJSON := requestor.Serialize()
+	requestorJSON := requestor.Serialize(app.EncryptionKey)
 	delete(requestorJSON, "gameID")
 
 	result := map[string]interface{}{
@@ -151,14 +151,14 @@ func dispatchApproveDenyMembershipHook(app *App, db models.DB, hookType int, gam
 	clanJSON := clan.Serialize()
 	delete(clanJSON, "gameID")
 
-	playerJSON := player.Serialize()
+	playerJSON := player.Serialize(app.EncryptionKey)
 	playerJSON["membershipLevel"] = playerMembershipLevel
 	delete(playerJSON, "gameID")
 
-	requestorJSON := requestor.Serialize()
+	requestorJSON := requestor.Serialize(app.EncryptionKey)
 	delete(requestorJSON, "gameID")
 
-	creatorJSON := creator.Serialize()
+	creatorJSON := creator.Serialize(app.EncryptionKey)
 	delete(creatorJSON, "gameID")
 
 	result := map[string]interface{}{

--- a/api/membership_helpers.go
+++ b/api/membership_helpers.go
@@ -50,14 +50,14 @@ func dispatchMembershipHookByPublicID(app *App, db models.DB, hookType int, game
 		return err
 	}
 
-	player, err := models.GetPlayerByPublicID(db, gameID, playerID)
+	player, err := models.GetPlayerByPublicID(db, app.EncryptionKey, gameID, playerID)
 	if err != nil {
 		return err
 	}
 
 	requestor := player
 	if requestorID != playerID {
-		requestor, err = models.GetPlayerByPublicID(db, gameID, requestorID)
+		requestor, err = models.GetPlayerByPublicID(db, app.EncryptionKey, gameID, requestorID)
 		if err != nil {
 			return err
 		}

--- a/api/membership_helpers.go
+++ b/api/membership_helpers.go
@@ -72,14 +72,14 @@ func dispatchMembershipHookByID(app *App, db models.DB, hookType int, gameID str
 		return err
 	}
 
-	player, err := models.GetPlayerByID(db, playerID)
+	player, err := models.GetPlayerByID(db, app.EncryptionKey, playerID)
 	if err != nil {
 		return err
 	}
 
 	requestor := player
 	if requestorID != playerID {
-		requestor, err = models.GetPlayerByID(db, requestorID)
+		requestor, err = models.GetPlayerByID(db, app.EncryptionKey, requestorID)
 		if err != nil {
 			return err
 		}
@@ -94,14 +94,14 @@ func dispatchApproveDenyMembershipHookByID(app *App, db models.DB, hookType int,
 		return err
 	}
 
-	player, err := models.GetPlayerByID(db, playerID)
+	player, err := models.GetPlayerByID(db, app.EncryptionKey, playerID)
 	if err != nil {
 		return err
 	}
 
 	requestor := player
 	if requestorID != playerID {
-		requestor, err = models.GetPlayerByID(db, requestorID)
+		requestor, err = models.GetPlayerByID(db, app.EncryptionKey, requestorID)
 		if err != nil {
 			return err
 		}
@@ -111,7 +111,7 @@ func dispatchApproveDenyMembershipHookByID(app *App, db models.DB, hookType int,
 	if creatorID != playerID {
 		creator = requestor
 		if creatorID != requestorID {
-			creator, err = models.GetPlayerByID(db, creatorID)
+			creator, err = models.GetPlayerByID(db, app.EncryptionKey, creatorID)
 			if err != nil {
 				return err
 			}

--- a/api/player.go
+++ b/api/player.go
@@ -78,7 +78,11 @@ func CreatePlayerHandler(app *App) func(c echo.Context) error {
 		}
 
 		err = WithSegment("hook-dispatch", c, func() error {
-			err = app.DispatchHooks(gameID, models.PlayerCreatedHook, player.Serialize())
+			err = app.DispatchHooks(
+				gameID,
+				models.PlayerCreatedHook,
+				player.Serialize(app.EncryptionKey),
+			)
 			if err != nil {
 				log.E(l, "Player creation hook dispatch failed.", func(cm log.CM) {
 					cm.Write(zap.Error(err))
@@ -184,7 +188,11 @@ func UpdatePlayerHandler(app *App) func(c echo.Context) error {
 			shouldDispatch := validateUpdatePlayerDispatch(game, beforeUpdatePlayer, player, payload.Metadata, l)
 			if shouldDispatch {
 				log.D(l, "Dispatching player update hooks...")
-				err = app.DispatchHooks(gameID, models.PlayerUpdatedHook, player.Serialize())
+				err = app.DispatchHooks(
+					gameID,
+					models.PlayerUpdatedHook,
+					player.Serialize(app.EncryptionKey),
+				)
 				if err != nil {
 					log.E(l, "Update player hook dispatch failed.", func(cm log.CM) {
 						cm.Write(zap.Error(err))

--- a/api/player.go
+++ b/api/player.go
@@ -49,6 +49,7 @@ func CreatePlayerHandler(app *App) func(c echo.Context) error {
 			log.D(l, "Creating player...")
 			player, err = models.CreatePlayer(
 				db,
+				app.EncryptionKey,
 				gameID,
 				payload.PublicID,
 				payload.Name,
@@ -158,6 +159,7 @@ func UpdatePlayerHandler(app *App) func(c echo.Context) error {
 				log.D(l, "Updating player...")
 				player, err = models.UpdatePlayer(
 					db,
+					app.EncryptionKey,
 					gameID,
 					playerPublicID,
 					payload.Name,

--- a/api/player.go
+++ b/api/player.go
@@ -143,7 +143,7 @@ func UpdatePlayerHandler(app *App) func(c echo.Context) error {
 
 		err = WithSegment("player-retrieve", c, func() error {
 			log.D(l, "Retrieving player...")
-			beforeUpdatePlayer, err = models.GetPlayerByPublicID(db, gameID, playerPublicID)
+			beforeUpdatePlayer, err = models.GetPlayerByPublicID(db, app.EncryptionKey, gameID, playerPublicID)
 			if err != nil && err.Error() != (&models.ModelNotFoundError{Type: "Player", ID: playerPublicID}).Error() {
 				return err
 			}
@@ -235,6 +235,7 @@ func RetrievePlayerHandler(app *App) func(c echo.Context) error {
 			log.D(l, "Retrieving player details...")
 			player, err = models.GetPlayerDetails(
 				db,
+				app.EncryptionKey,
 				gameID,
 				publicID,
 			)

--- a/api/player_test.go
+++ b/api/player_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Player API Handler", func() {
 	Describe("Retrieve Player", func() {
 		It("Should retrieve player", func() {
 			gameID := uuid.NewV4().String()
-			player, err := models.GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
+			_, player, err := models.GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
 			Expect(err).NotTo(HaveOccurred())
 
 			route := GetGameRoute(player.GameID, fmt.Sprintf("/players/%s", player.PublicID))

--- a/api/player_test.go
+++ b/api/player_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/Pallinder/go-randomdata"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/api"
 	"github.com/topfreegames/khan/models"
 )
@@ -56,7 +56,7 @@ var _ = Describe("Player API Handler", func() {
 			Expect(result["publicID"]).To(Equal(payload["publicID"].(string)))
 
 			dbPlayer, err := models.GetPlayerByPublicID(
-				db, game.PublicID, payload["publicID"].(string),
+				db, a.EncryptionKey, game.PublicID, payload["publicID"].(string),
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dbPlayer.GameID).To(Equal(game.PublicID))
@@ -125,7 +125,7 @@ var _ = Describe("Player API Handler", func() {
 			json.Unmarshal([]byte(body), &result)
 			Expect(result["success"]).To(BeTrue())
 
-			dbPlayer, err := models.GetPlayerByPublicID(db, player.GameID, player.PublicID)
+			dbPlayer, err := models.GetPlayerByPublicID(db, a.EncryptionKey, player.GameID, player.PublicID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dbPlayer.GameID).To(Equal(player.GameID))
 			Expect(dbPlayer.PublicID).To(Equal(player.PublicID))

--- a/bench/player_test.go
+++ b/bench/player_test.go
@@ -84,7 +84,7 @@ func BenchmarkRetrievePlayer(b *testing.B) {
 	}
 
 	gameID := uuid.NewV4().String()
-	player, err := models.GetTestPlayerWithMemberships(db, gameID, 50, 20, 30, 80)
+	_, player, err := models.GetTestPlayerWithMemberships(db, gameID, 50, 20, 30, 80)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/bench/player_test.go
+++ b/bench/player_test.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/models"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/uber-go/zap v0.0.0-20160809182253-d11d2851fcab
 	github.com/valyala/fasthttp v0.0.0-20160818100357-834fb48f1040
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4
+	github.com/wildlife-studios/crypto v1.1.0
 	github.com/yuin/goldmark v1.3.2 // indirect
 	github.com/ziutek/mymysql v1.5.5-0.20160909221029-df6241f6355c // indirect
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,8 @@ github.com/valyala/fasthttp v0.0.0-20160818100357-834fb48f1040 h1:Uc5jsQ7/Ts1kGf
 github.com/valyala/fasthttp v0.0.0-20160818100357-834fb48f1040/go.mod h1:+g/po7GqyG5E+1CNgquiIxJnsXEi5vwFn5weFujbO78=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QINDnvyZuTaACm9ofY+PRh+5vFz4oxBZeF8=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
+github.com/wildlife-studios/crypto v1.1.0 h1:4SNqOCPxku23Y3jpUG5GpVZ9nSkbEDoE08MpsQU+pzA=
+github.com/wildlife-studios/crypto v1.1.0/go.mod h1:Jh6AuI77BkcVhIw0885e7KGPVg3OFyNWm7XnqH8HNsE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -471,6 +473,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/models/clan.go
+++ b/models/clan.go
@@ -487,8 +487,8 @@ func GetClanByPublicIDAndOwnerPublicID(db DB, gameID, publicID, ownerPublicID st
 }
 
 // CreateClan creates a new clan
-func CreateClan(db DB, gameID, publicID, name, ownerPublicID string, metadata map[string]interface{}, allowApplication, autoJoin bool, maxClansPerPlayer int) (*Clan, error) {
-	player, err := GetPlayerByPublicID(db, gameID, ownerPublicID)
+func CreateClan(db DB, encryptionKey []byte, gameID, publicID, name, ownerPublicID string, metadata map[string]interface{}, allowApplication, autoJoin bool, maxClansPerPlayer int) (*Clan, error) {
+	player, err := GetPlayerByPublicID(db, encryptionKey, gameID, ownerPublicID)
 	if err != nil {
 		return nil, err
 	}

--- a/models/clan.go
+++ b/models/clan.go
@@ -522,14 +522,14 @@ func CreateClan(db DB, gameID, publicID, name, ownerPublicID string, metadata ma
 }
 
 // LeaveClan allows the clan owner to leave the clan and transfer the clan ownership to the next player in line
-func LeaveClan(db DB, gameID, publicID string) (*Clan, *Player, *Player, error) {
+func LeaveClan(db DB, encryptionKey []byte, gameID, publicID string) (*Clan, *Player, *Player, error) {
 	clan, err := GetClanByPublicID(db, gameID, publicID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
 	oldOwnerID := clan.OwnerID
-	oldOwner, err := GetPlayerByID(db, oldOwnerID)
+	oldOwner, err := GetPlayerByID(db, encryptionKey, oldOwnerID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -556,7 +556,7 @@ func LeaveClan(db DB, gameID, publicID string) (*Clan, *Player, *Player, error) 
 		return nil, nil, nil, err
 	}
 
-	newOwner, err := GetPlayerByID(db, newOwnerMembership.PlayerID)
+	newOwner, err := GetPlayerByID(db, encryptionKey, newOwnerMembership.PlayerID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -593,7 +593,7 @@ func LeaveClan(db DB, gameID, publicID string) (*Clan, *Player, *Player, error) 
 }
 
 // TransferClanOwnership allows the clan owner to transfer the clan ownership to a clan member
-func TransferClanOwnership(db DB, gameID, clanPublicID, playerPublicID string, levels map[string]interface{}, maxLevel int) (*Clan, *Player, *Player, error) {
+func TransferClanOwnership(db DB, encryptionKey []byte, gameID, clanPublicID, playerPublicID string, levels map[string]interface{}, maxLevel int) (*Clan, *Player, *Player, error) {
 	clan, err := GetClanByPublicID(db, gameID, clanPublicID)
 	if err != nil {
 		return nil, nil, nil, err
@@ -657,7 +657,7 @@ func TransferClanOwnership(db DB, gameID, clanPublicID, playerPublicID string, l
 		return nil, nil, nil, err
 	}
 
-	newOwner, err := GetPlayerByID(db, newOwnerMembership.PlayerID)
+	newOwner, err := GetPlayerByID(db, encryptionKey, newOwnerMembership.PlayerID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -672,7 +672,7 @@ func TransferClanOwnership(db DB, gameID, clanPublicID, playerPublicID string, l
 		return nil, nil, nil, err
 	}
 
-	oldOwner, err := GetPlayerByID(db, oldOwnerID)
+	oldOwner, err := GetPlayerByID(db, encryptionKey, oldOwnerID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1018,12 +1018,12 @@ func SearchClan(
 }
 
 // GetClanAndOwnerByPublicID returns the clan as well as the owner of a clan by clan's public id
-func GetClanAndOwnerByPublicID(db DB, gameID, publicID string) (*Clan, *Player, error) {
+func GetClanAndOwnerByPublicID(db DB, encryptionKey []byte, gameID, publicID string) (*Clan, *Player, error) {
 	clan, err := GetClanByPublicID(db, gameID, publicID)
 	if err != nil {
 		return nil, nil, err
 	}
-	newOwner, err := GetPlayerByID(db, clan.OwnerID)
+	newOwner, err := GetPlayerByID(db, encryptionKey, clan.OwnerID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/models/clan_easyjson.go
+++ b/models/clan_easyjson.go
@@ -28,7 +28,7 @@ func easyjson91eb9988DecodeGithubComTopfreegamesKhanModels(in *jlexer.Lexer, out
 	}
 	in.Delim('{')
 	for !in.IsDelim('}') {
-		key := in.UnsafeString()
+		key := in.UnsafeFieldName(false)
 		in.WantColon()
 		if in.IsNull() {
 			in.Skip()

--- a/models/clan_test.go
+++ b/models/clan_test.go
@@ -318,7 +318,7 @@ var _ = Describe("Clan Model", func() {
 				Expect(dbClan.PublicID).To(Equal(clan.PublicID))
 				Expect(dbClan.MembershipCount).To(Equal(1))
 
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.OwnershipCount).To(Equal(1))
 			})
@@ -517,7 +517,7 @@ var _ = Describe("Clan Model", func() {
 					_, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
-					clan, previousOwner, newOwner, err := LeaveClan(testDb, clan.GameID, clan.PublicID)
+					clan, previousOwner, newOwner, err := LeaveClan(testDb, GetEncryptionKey(), clan.GameID, clan.PublicID)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(previousOwner.ID).To(Equal(owner.ID))
@@ -531,11 +531,11 @@ var _ = Describe("Clan Model", func() {
 					Expect(dbDeletedMembership.DeletedBy).To(Equal(memberships[0].PlayerID))
 					Expect(dbDeletedMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-					dbPlayer, err := GetPlayerByID(testDb, owner.ID)
+					dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), owner.ID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 
-					dbPlayer, err = GetPlayerByID(testDb, memberships[0].PlayerID)
+					dbPlayer, err = GetPlayerByID(testDb, GetEncryptionKey(), memberships[0].PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(1))
 					Expect(dbPlayer.MembershipCount).To(Equal(0))
@@ -549,7 +549,7 @@ var _ = Describe("Clan Model", func() {
 					_, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
-					clan, previousOwner, newOwner, err := LeaveClan(testDb, clan.GameID, clan.PublicID)
+					clan, previousOwner, newOwner, err := LeaveClan(testDb, GetEncryptionKey(), clan.GameID, clan.PublicID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(previousOwner.ID).To(Equal(owner.ID))
 					Expect(newOwner).To(BeNil())
@@ -558,7 +558,7 @@ var _ = Describe("Clan Model", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal(fmt.Sprintf("Clan was not found with id: %s", clan.PublicID)))
 
-					dbPlayer, err := GetPlayerByID(testDb, owner.ID)
+					dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), owner.ID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 				})
@@ -570,7 +570,7 @@ var _ = Describe("Clan Model", func() {
 					_, clan, _, _, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
-					_, _, _, err = LeaveClan(testDb, clan.GameID, "-1")
+					_, _, _, err = LeaveClan(testDb, GetEncryptionKey(), clan.GameID, "-1")
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("Clan was not found with id: -1"))
 				})
@@ -584,6 +584,7 @@ var _ = Describe("Clan Model", func() {
 					Expect(err).NotTo(HaveOccurred())
 					clan, previousOwner, newOwner, err := TransferClanOwnership(
 						testDb,
+						GetEncryptionKey(),
 						clan.GameID,
 						clan.PublicID,
 						players[0].PublicID,
@@ -610,12 +611,12 @@ var _ = Describe("Clan Model", func() {
 					Expect(newOwnerMembership.DeletedBy).To(Equal(newOwnerMembership.PlayerID))
 					Expect(newOwnerMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-					dbPlayer, err := GetPlayerByID(testDb, owner.ID)
+					dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), owner.ID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 					Expect(dbPlayer.MembershipCount).To(Equal(1))
 
-					dbPlayer, err = GetPlayerByID(testDb, newOwnerMembership.PlayerID)
+					dbPlayer, err = GetPlayerByID(testDb, GetEncryptionKey(), newOwnerMembership.PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(1))
 					Expect(dbPlayer.MembershipCount).To(Equal(0))
@@ -627,6 +628,7 @@ var _ = Describe("Clan Model", func() {
 
 					clan, previousOwner, newOwner, err := TransferClanOwnership(
 						testDb,
+						GetEncryptionKey(),
 						clan.GameID,
 						clan.PublicID,
 						players[0].PublicID,
@@ -639,6 +641,7 @@ var _ = Describe("Clan Model", func() {
 
 					clan, previousOwner, newOwner, err = TransferClanOwnership(
 						testDb,
+						GetEncryptionKey(),
 						clan.GameID,
 						clan.PublicID,
 						players[1].PublicID,
@@ -669,17 +672,17 @@ var _ = Describe("Clan Model", func() {
 					Expect(newOwnerMembership.DeletedBy).To(Equal(newOwnerMembership.PlayerID))
 					Expect(newOwnerMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-					dbPlayer, err := GetPlayerByID(testDb, firstOwnerMembership.PlayerID)
+					dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), firstOwnerMembership.PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 					Expect(dbPlayer.MembershipCount).To(Equal(1))
 
-					dbPlayer, err = GetPlayerByID(testDb, previousOwnerMembership.PlayerID)
+					dbPlayer, err = GetPlayerByID(testDb, GetEncryptionKey(), previousOwnerMembership.PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 					Expect(dbPlayer.MembershipCount).To(Equal(1))
 
-					dbPlayer, err = GetPlayerByID(testDb, newOwnerMembership.PlayerID)
+					dbPlayer, err = GetPlayerByID(testDb, GetEncryptionKey(), newOwnerMembership.PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(1))
 					Expect(dbPlayer.MembershipCount).To(Equal(0))
@@ -693,6 +696,7 @@ var _ = Describe("Clan Model", func() {
 
 					_, _, _, err = TransferClanOwnership(
 						testDb,
+						GetEncryptionKey(),
 						clan.GameID,
 						"-1",
 						players[0].PublicID,
@@ -709,6 +713,7 @@ var _ = Describe("Clan Model", func() {
 
 					_, _, _, err = TransferClanOwnership(
 						testDb,
+						GetEncryptionKey(),
 						clan.GameID,
 						clan.PublicID,
 						"some-random-player",
@@ -1144,7 +1149,7 @@ var _ = Describe("Clan Model", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				dbClan, dbOwner, err := GetClanAndOwnerByPublicID(testDb, clan.GameID, clan.PublicID)
+				dbClan, dbOwner, err := GetClanAndOwnerByPublicID(testDb, GetEncryptionKey(), clan.GameID, clan.PublicID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbClan.ID).To(Equal(clan.ID))
 				Expect(dbOwner.ID).To(Equal(owner.ID))

--- a/models/clan_test.go
+++ b/models/clan_test.go
@@ -964,9 +964,9 @@ var _ = Describe("Clan Model", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				updateEncryptingTestPlayer(testDb, owner)
+				testing.UpdateEncryptingTestPlayer(testDb, GetEncryptionKey(), owner)
 				for _, player := range players {
-					updateEncryptingTestPlayer(testDb, player)
+					testing.UpdateEncryptingTestPlayer(testDb, GetEncryptionKey(), player)
 				}
 
 				config := viper.New()
@@ -995,7 +995,8 @@ var _ = Describe("Clan Model", func() {
 
 				playerDict := map[string]*Player{}
 				for _, player := range players {
-					playerDict[player.PublicID] = decryptTestPlayer(player)
+					testing.DecryptTestPlayer(GetEncryptionKey(), player)
+					playerDict[player.PublicID] = player
 				}
 
 				for _, playerData := range roster {

--- a/models/clan_test.go
+++ b/models/clan_test.go
@@ -298,6 +298,7 @@ var _ = Describe("Clan Model", func() {
 
 				clan, err := CreateClan(
 					testDb,
+					GetEncryptionKey(),
 					player.GameID,
 					"create-1",
 					randomdata.FullName(randomdata.RandomGender),
@@ -329,6 +330,7 @@ var _ = Describe("Clan Model", func() {
 
 				_, err = CreateClan(
 					testDb,
+					GetEncryptionKey(),
 					player.GameID,
 					strings.Repeat("a", 256),
 					"clan-name",
@@ -349,6 +351,7 @@ var _ = Describe("Clan Model", func() {
 
 				_, err = CreateClan(
 					testDb,
+					GetEncryptionKey(),
 					owner.GameID,
 					"create-1",
 					randomdata.FullName(randomdata.RandomGender),
@@ -369,6 +372,7 @@ var _ = Describe("Clan Model", func() {
 
 				_, err = CreateClan(
 					testDb,
+					GetEncryptionKey(),
 					game.PublicID,
 					"create-1",
 					randomdata.FullName(randomdata.RandomGender),
@@ -388,6 +392,7 @@ var _ = Describe("Clan Model", func() {
 				playerPublicID := randomdata.FullName(randomdata.RandomGender)
 				_, err = CreateClan(
 					testDb,
+					GetEncryptionKey(),
 					"create-1",
 					randomdata.FullName(randomdata.RandomGender),
 					"clan-name",

--- a/models/clan_test.go
+++ b/models/clan_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/api"
-	"github.com/topfreegames/khan/models"
 	. "github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/testing"
 	"github.com/topfreegames/khan/util"
@@ -1307,20 +1306,3 @@ var _ = Describe("Clan Model", func() {
 		})
 	})
 })
-
-func decryptTestPlayer(player *models.Player) *Player {
-	name, err := util.DecryptData(player.Name, GetEncryptionKey())
-	Expect(err).NotTo(HaveOccurred())
-	player.Name = name
-	return player
-}
-
-func updateEncryptingTestPlayer(db DB, player *models.Player) {
-	name, err := util.EncryptData(player.Name, GetEncryptionKey())
-	Expect(err).NotTo(HaveOccurred())
-	player.Name = name
-	rows, err := db.Update(player)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(rows).To(BeEquivalentTo(1))
-
-}

--- a/models/clan_test.go
+++ b/models/clan_test.go
@@ -765,7 +765,7 @@ var _ = Describe("Clan Model", func() {
 				)
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 
 				clanPlayers, err := GetClanMembers(testDb, clan.GameID, clan.PublicID)
@@ -786,7 +786,7 @@ var _ = Describe("Clan Model", func() {
 				)
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 
 				clanPlayers, err := GetClanMembers(testDb, clan.GameID, clan.PublicID)
@@ -807,7 +807,7 @@ var _ = Describe("Clan Model", func() {
 
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clanData["name"]).To(Equal(clan.Name))
 				Expect(clanData["metadata"]).To(Equal(clan.Metadata))
@@ -913,7 +913,7 @@ var _ = Describe("Clan Model", func() {
 
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clanData["name"]).To(Equal(clan.Name))
 				Expect(clanData["metadata"]).To(Equal(clan.Metadata))
@@ -947,7 +947,7 @@ var _ = Describe("Clan Model", func() {
 
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clanData["name"]).To(Equal(clan.Name))
 				Expect(clanData["metadata"]).To(Equal(clan.Metadata))
@@ -1046,7 +1046,7 @@ var _ = Describe("Clan Model", func() {
 			It("Should fail if clan does not exist", func() {
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, "fake-game-id", &Clan{PublicID: "fake-public-id"}, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), "fake-game-id", &Clan{PublicID: "fake-public-id"}, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(clanData).To(BeNil())
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Clan was not found with id: fake-public-id"))
@@ -1075,7 +1075,7 @@ var _ = Describe("Clan Model", func() {
 			It("Should fail if clan does not exist", func() {
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, "fake-game-id", &Clan{PublicID: "fake-public-id"}, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), "fake-game-id", &Clan{PublicID: "fake-public-id"}, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(clanData).To(BeNil())
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Clan was not found with id: fake-public-id"))

--- a/models/fixtures.go
+++ b/models/fixtures.go
@@ -564,7 +564,7 @@ func GetTestHooks(db DB, gameID string, numberOfHooks int) ([]*Hook, error) {
 	return hooks, nil
 }
 
-//GetTestPlayerWithMemberships returns a player with approved, rejected and banned memberships
+//GetTestPlayerWithMemberships returns the clan owner, a player with approved, rejected, and banned memberships
 func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rejectedMemberships, bannedMemberships, pendingMemberships int) (*Player, *Player, error) {
 	if gameID == "" {
 		gameID = uuid.NewV4().String()

--- a/models/fixtures.go
+++ b/models/fixtures.go
@@ -565,7 +565,7 @@ func GetTestHooks(db DB, gameID string, numberOfHooks int) ([]*Hook, error) {
 }
 
 //GetTestPlayerWithMemberships returns a player with approved, rejected and banned memberships
-func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rejectedMemberships, bannedMemberships, pendingMemberships int) (*Player, error) {
+func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rejectedMemberships, bannedMemberships, pendingMemberships int) (*Player, *Player, error) {
 	if gameID == "" {
 		gameID = uuid.NewV4().String()
 	}
@@ -574,7 +574,7 @@ func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rej
 	}).(*Game)
 	err := db.Insert(game)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	owner := PlayerFactory.MustCreateWithOption(map[string]interface{}{
@@ -583,7 +583,7 @@ func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rej
 	}).(*Player)
 	err = db.Insert(owner)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
@@ -592,7 +592,7 @@ func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rej
 	}).(*Player)
 	err = db.Insert(player)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	createClan := func() (*Clan, error) {
@@ -652,29 +652,29 @@ func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rej
 	for i := 0; i < approvedMemberships; i++ {
 		_, err := createMembership(true, false, false)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	for i := 0; i < rejectedMemberships; i++ {
 		_, err := createMembership(false, true, false)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	for i := 0; i < bannedMemberships; i++ {
 		_, err := createMembership(false, false, true)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	for i := 0; i < pendingMemberships; i++ {
 		_, err := createMembership(false, false, false)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	return player, nil
+	return owner, player, nil
 }
 
 //GetTestClanWithStaleData returns a player with approved, rejected and banned memberships

--- a/models/fixtures.go
+++ b/models/fixtures.go
@@ -117,6 +117,13 @@ func configureFactory(fct *factory.Factory) *factory.Factory {
 	})
 }
 
+var encryptionKey []byte = []byte("00000000000000000000000000000000")
+
+//GetEncryptionKey returns the models test encryptionKey
+func GetEncryptionKey() []byte {
+	return encryptionKey
+}
+
 // PlayerFactory is responsible for constructing test player instances
 var PlayerFactory = configureFactory(factory.NewFactory(
 	&Player{},

--- a/models/fixtures.go
+++ b/models/fixtures.go
@@ -117,11 +117,11 @@ func configureFactory(fct *factory.Factory) *factory.Factory {
 	})
 }
 
-var encryptionKey []byte = []byte("00000000000000000000000000000000")
+var testKey []byte = []byte("00000000000000000000000000000000")
 
 //GetEncryptionKey returns the models test encryptionKey
 func GetEncryptionKey() []byte {
-	return encryptionKey
+	return testKey
 }
 
 // PlayerFactory is responsible for constructing test player instances

--- a/models/helpers_test.go
+++ b/models/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	workers "github.com/jrallison/go-workers"
+	. "github.com/onsi/gomega"
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/extensions/v9/mongo/interfaces"
@@ -19,6 +20,7 @@ import (
 	"github.com/topfreegames/khan/mongo"
 	"github.com/topfreegames/khan/queues"
 	kt "github.com/topfreegames/khan/testing"
+	"github.com/topfreegames/khan/util"
 )
 
 // GetTestDB returns a connection to the test database
@@ -87,4 +89,21 @@ func ConfigureAndStartGoWorkers() error {
 	workers.Process(queues.KhanMongoQueue, mongoWorker.PerformUpdateMongo, workerCount)
 	workers.Start()
 	return nil
+}
+
+func decryptTestPlayer(player *models.Player) *models.Player {
+	name, err := util.DecryptData(player.Name, models.GetEncryptionKey())
+	Expect(err).NotTo(HaveOccurred())
+	player.Name = name
+	return player
+}
+
+func updateEncryptingTestPlayer(db models.DB, player *models.Player) {
+	name, err := util.EncryptData(player.Name, models.GetEncryptionKey())
+	Expect(err).NotTo(HaveOccurred())
+	player.Name = name
+	rows, err := db.Update(player)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(rows).To(BeEquivalentTo(1))
+
 }

--- a/models/helpers_test.go
+++ b/models/helpers_test.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 
 	workers "github.com/jrallison/go-workers"
-	. "github.com/onsi/gomega"
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/viper"
 	"github.com/topfreegames/extensions/v9/mongo/interfaces"
@@ -20,7 +19,6 @@ import (
 	"github.com/topfreegames/khan/mongo"
 	"github.com/topfreegames/khan/queues"
 	kt "github.com/topfreegames/khan/testing"
-	"github.com/topfreegames/khan/util"
 )
 
 // GetTestDB returns a connection to the test database
@@ -89,21 +87,4 @@ func ConfigureAndStartGoWorkers() error {
 	workers.Process(queues.KhanMongoQueue, mongoWorker.PerformUpdateMongo, workerCount)
 	workers.Start()
 	return nil
-}
-
-func decryptTestPlayer(player *models.Player) *models.Player {
-	name, err := util.DecryptData(player.Name, models.GetEncryptionKey())
-	Expect(err).NotTo(HaveOccurred())
-	player.Name = name
-	return player
-}
-
-func updateEncryptingTestPlayer(db models.DB, player *models.Player) {
-	name, err := util.EncryptData(player.Name, models.GetEncryptionKey())
-	Expect(err).NotTo(HaveOccurred())
-	player.Name = name
-	rows, err := db.Update(player)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(rows).To(BeEquivalentTo(1))
-
 }

--- a/models/membership.go
+++ b/models/membership.go
@@ -260,7 +260,7 @@ func ApproveOrDenyMembershipApplication(db DB, encryptionKey []byte, game *Game,
 		return nil, &PlayerCannotPerformMembershipActionError{action, playerPublicID, clanPublicID, requestorPublicID}
 	}
 
-	requestor, err := GetPlayerByPublicID(db, gameID, requestorPublicID)
+	requestor, err := GetPlayerByPublicID(db, encryptionKey, gameID, requestorPublicID)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +391,7 @@ func validateMembership(db DB, encryptionKey []byte, game *Game, membership *Mem
 			return -1, false, err
 		}
 	} else {
-		player, err := GetPlayerByPublicID(db, game.PublicID, playerPublicID)
+		player, err := GetPlayerByPublicID(db, encryptionKey, game.PublicID, playerPublicID)
 		if err != nil {
 			return -1, false, err
 		}
@@ -423,7 +423,7 @@ func applyForMembership(db DB, game *Game, membership *Membership, level string,
 func inviteMember(db DB, encryptionKey []byte, game *Game, membership *Membership, level string, clan *Clan, playerID int64, requestorPublicID, message string, previousMembership bool) (*Membership, error) {
 	reqMembership, _ := GetValidMembershipByClanAndPlayerPublicID(db, game.PublicID, clan.PublicID, requestorPublicID)
 	if reqMembership == nil {
-		requestor, err := GetPlayerByPublicID(db, game.PublicID, requestorPublicID)
+		requestor, err := GetPlayerByPublicID(db, encryptionKey, game.PublicID, requestorPublicID)
 		if err != nil {
 			return nil, err
 		}

--- a/models/membership_test.go
+++ b/models/membership_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Membership Model", func() {
 	Describe("Membership Model", func() {
 		Describe("Get Number of Pending Invites", func() {
 			It("Should get number of pending invites", func() {
-				player, err := GetTestPlayerWithMemberships(testDb, uuid.NewV4().String(), 0, 0, 0, 20)
+				_, player, err := GetTestPlayerWithMemberships(testDb, uuid.NewV4().String(), 0, 0, 0, 20)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(player).NotTo(BeEquivalentTo(nil))
 
@@ -59,7 +59,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Should not create a new membership for a member with max number of invitations", func() {
 				gameID := uuid.NewV4().String()
-				player, err := GetTestPlayerWithMemberships(testDb, gameID, 0, 0, 0, 20)
+				_, player, err := GetTestPlayerWithMemberships(testDb, gameID, 0, 0, 0, 20)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(player).NotTo(BeEquivalentTo(nil))
 
@@ -124,7 +124,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Should create a new membership for a member when game MaxPendingInvites is -1", func() {
 				gameID := uuid.NewV4().String()
-				player, err := GetTestPlayerWithMemberships(testDb, gameID, 0, 0, 0, 20)
+				_, player, err := GetTestPlayerWithMemberships(testDb, gameID, 0, 0, 0, 20)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(player).NotTo(BeEquivalentTo(nil))
 

--- a/models/membership_test.go
+++ b/models/membership_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Pallinder/go-randomdata"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/util"
 )
@@ -73,6 +73,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -102,6 +103,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -139,6 +141,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -162,6 +165,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					players[0].PublicID,
@@ -192,6 +196,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -203,6 +208,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -229,6 +235,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -240,6 +247,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -260,6 +268,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -271,6 +280,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -301,6 +311,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -312,6 +323,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -337,6 +349,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -348,6 +361,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -379,6 +393,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -390,6 +405,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -426,6 +442,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -437,6 +454,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -470,6 +488,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -481,6 +500,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -676,6 +696,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -699,7 +720,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -733,6 +754,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -756,7 +778,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.DeletedAt).To(Equal(int64(0)))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, players[0].ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), players[0].ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -782,6 +804,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -805,7 +828,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -826,6 +849,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -868,6 +892,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -905,6 +930,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -928,7 +954,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -955,6 +981,7 @@ var _ = Describe("Membership Model", func() {
 				time.Sleep(time.Second)
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -978,7 +1005,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -1004,6 +1031,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1039,6 +1067,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1062,6 +1091,7 @@ var _ = Describe("Membership Model", func() {
 				time.Sleep(time.Second)
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1084,7 +1114,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -1110,6 +1140,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1133,7 +1164,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -1150,6 +1181,7 @@ var _ = Describe("Membership Model", func() {
 				// deny application
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1172,6 +1204,7 @@ var _ = Describe("Membership Model", func() {
 				// apply for membership again
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1189,7 +1222,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Approved).To(BeTrue())
 				Expect(dbMembership.Denied).To(Equal(false))
 
-				dbPlayer, err := GetPlayerByID(testDb, dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -1217,6 +1250,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1244,6 +1278,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1269,6 +1304,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1297,6 +1333,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -1325,6 +1362,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -1354,6 +1392,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1376,6 +1415,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					owner.GameID,
 					"Member",
@@ -1396,6 +1436,7 @@ var _ = Describe("Membership Model", func() {
 				clanPublicID := randomdata.FullName(randomdata.RandomGender)
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1423,6 +1464,7 @@ var _ = Describe("Membership Model", func() {
 				requestorPublicID := randomdata.FullName(randomdata.RandomGender)
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1454,6 +1496,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1480,6 +1523,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1499,6 +1543,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					clan.GameID,
 					"Member",
@@ -1522,6 +1567,7 @@ var _ = Describe("Membership Model", func() {
 
 				updatedMembership, err := ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1542,7 +1588,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.ApproverID.Valid).To(BeTrue())
 				Expect(dbMembership.ApproverID.Int64).To(Equal(int64(players[0].ID)))
 
-				dbPlayer, err := GetPlayerByID(testDb, players[0].ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), players[0].ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -1560,6 +1606,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[1].GameID,
 					players[1].PublicID,
@@ -1598,6 +1645,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1620,6 +1668,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1644,6 +1693,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					player.GameID,
 					player.PublicID,
@@ -1667,6 +1717,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1689,6 +1740,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1711,6 +1763,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1731,6 +1784,7 @@ var _ = Describe("Membership Model", func() {
 
 				updatedMembership, err := ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1760,6 +1814,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1783,6 +1838,7 @@ var _ = Describe("Membership Model", func() {
 
 				updatedMembership, err := ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1803,7 +1859,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.ApproverID.Valid).To(BeTrue())
 				Expect(dbMembership.ApproverID.Int64).To(Equal(int64(owner.ID)))
 
-				dbPlayer, err := GetPlayerByID(testDb, players[0].ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), players[0].ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -1827,6 +1883,7 @@ var _ = Describe("Membership Model", func() {
 
 				updatedMembership, err := ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[1].GameID,
 					players[1].PublicID,
@@ -1848,7 +1905,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Approved).To(Equal(true))
 				Expect(dbMembership.Denied).To(Equal(false))
 
-				dbPlayer, err := GetPlayerByID(testDb, players[1].ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), players[1].ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -1870,6 +1927,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[1].GameID,
 					players[1].PublicID,
@@ -1909,6 +1967,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1937,6 +1996,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1965,6 +2025,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1994,6 +2055,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2022,6 +2084,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2045,6 +2108,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2064,6 +2128,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2089,6 +2154,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					clan.GameID,
 					player.PublicID,
@@ -2113,6 +2179,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2137,6 +2204,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2162,6 +2230,7 @@ var _ = Describe("Membership Model", func() {
 
 				updatedMembership, err := ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -2196,6 +2265,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
+					GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -2592,7 +2662,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-				dbPlayer, err := GetPlayerByID(testDb, memberships[0].PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), memberships[0].PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -2623,7 +2693,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-				dbPlayer, err := GetPlayerByID(testDb, memberships[0].PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), memberships[0].PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -2657,7 +2727,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-				dbPlayer, err := GetPlayerByID(testDb, memberships[0].PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), memberships[0].PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 

--- a/models/player.go
+++ b/models/player.go
@@ -297,7 +297,10 @@ func GetPlayerMembershipDetails(db DB, encryptionKey []byte, gameID, publicID st
 
 	result := make(map[string]interface{})
 
-	result["name"] = details[0].PlayerName
+	result["name"], err = util.DecryptData(details[0].PlayerName, encryptionKey)
+	if err != nil {
+		result["name"] = details[0].PlayerName
+	}
 	result["metadata"] = details[0].PlayerMetadata
 	result["publicID"] = details[0].PlayerPublicID
 	result["createdAt"] = details[0].PlayerCreatedAt

--- a/models/player.go
+++ b/models/player.go
@@ -365,28 +365,28 @@ func getPlayerMembershipDetails(db DB, encryptionKey []byte, gameID, publicID st
 		}
 
 		for _, detail := range details {
-			membershipApproved := nullOrBool(detail.MembershipApproved)
-			membershipDenied := nullOrBool(detail.MembershipDenied)
-			membershipBanned := nullOrBool(detail.MembershipBanned)
-			membershipDeleted := !membershipBanned && detail.MembershipDeletedAt.Valid && detail.MembershipDeletedAt.Int64 > 0
+			approvedMembership := nullOrBool(detail.MembershipApproved)
+			deniedMembership := nullOrBool(detail.MembershipDenied)
+			bannedMembership := nullOrBool(detail.MembershipBanned)
+			deletedMembership := !bannedMembership && detail.MembershipDeletedAt.Valid && detail.MembershipDeletedAt.Int64 > 0
 
-			if !membershipDeleted {
+			if !deletedMembership {
 				membership := detail.Serialize(encryptionKey)
 				memberships = append(memberships, membership)
 
 				clanDetail := clanFromDetail(detail)
 				switch {
-				case !membershipApproved && !membershipDenied && !membershipBanned:
+				case !approvedMembership && !deniedMembership && !bannedMembership:
 					if detail.RequestorPublicID.Valid && detail.RequestorPublicID.String == detail.PlayerPublicID {
 						pendingApplications = append(pendingApplications, clanDetail)
 					} else {
 						pendingInvites = append(pendingInvites, clanDetail)
 					}
-				case membershipApproved:
+				case approvedMembership:
 					approved = append(approved, clanDetail)
-				case membershipDenied:
+				case deniedMembership:
 					denied = append(denied, clanDetail)
-				case membershipBanned:
+				case bannedMembership:
 					banned = append(banned, clanDetail)
 				}
 			}

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -510,6 +510,36 @@ var _ = Describe("Player Model", func() {
 				Expect(len(pendingInvites)).To(Equal(0))
 			})
 
+			It("Should get Player Details decrypting player.Name", func() {
+				_, player, err := CreatePlayerFactory(testDb, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				encryptedName, err := util.EncryptData(player.Name, GetEncryptionKey())
+				Expect(err).NotTo(HaveOccurred())
+
+				name := player.Name
+				player.Name = encryptedName
+				count, err := testDb.Update(player)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(int(count)).To(Equal(1))
+
+				playerDetails, err := GetPlayerDetails(
+					testDb,
+					GetEncryptionKey(),
+					player.GameID,
+					player.PublicID,
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				// Player Details
+				Expect(playerDetails["publicID"]).To(Equal(player.PublicID))
+				Expect(playerDetails["name"]).To(Equal(name))
+				Expect(playerDetails["createdAt"]).To(Equal(player.CreatedAt))
+				Expect(playerDetails["updatedAt"]).To(Equal(player.UpdatedAt))
+
+			})
+
 			It("Should return error if Player does not exist", func() {
 				playerDetails, err := GetPlayerDetails(
 					testDb,

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -225,7 +225,7 @@ var _ = Describe("Player Model", func() {
 		Describe("Get Player Details", func() {
 			It("Should get Player Details", func() {
 				gameID := uuid.NewV4().String()
-				player, err := GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
+				_, player, err := GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
 				Expect(err).NotTo(HaveOccurred())
 
 				playerDetails, err := GetPlayerDetails(
@@ -567,7 +567,7 @@ var _ = Describe("Player Model", func() {
 		Describe("Update Player Membership Count", func() {
 			It("Should work if membership is created", func() {
 				prevMemberships := 5
-				player, err := GetTestPlayerWithMemberships(testDb, "", prevMemberships, 2, 3, 4)
+				_, player, err := GetTestPlayerWithMemberships(testDb, "", prevMemberships, 2, 3, 4)
 				Expect(err).NotTo(HaveOccurred())
 
 				clan := ClanFactory.MustCreateWithOption(map[string]interface{}{
@@ -603,7 +603,7 @@ var _ = Describe("Player Model", func() {
 
 			It("Should work if membership is deleted", func() {
 				prevMemberships := 5
-				player, err := GetTestPlayerWithMemberships(testDb, "", prevMemberships, 2, 3, 4)
+				_, player, err := GetTestPlayerWithMemberships(testDb, "", prevMemberships, 2, 3, 4)
 				Expect(err).NotTo(HaveOccurred())
 
 				var membership *Membership

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/testing"
 	"github.com/topfreegames/khan/util"
 
 	uuid "github.com/satori/go.uuid"
@@ -515,8 +516,8 @@ var _ = Describe("Player Model", func() {
 				owner, player, err := GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
 				Expect(err).NotTo(HaveOccurred())
 
-				updateEncryptingTestPlayer(testDb, owner)
-				updateEncryptingTestPlayer(testDb, player)
+				testing.UpdateEncryptingTestPlayer(testDb, GetEncryptionKey(), owner)
+				testing.UpdateEncryptingTestPlayer(testDb, GetEncryptionKey(), player)
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
@@ -527,7 +528,7 @@ var _ = Describe("Player Model", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 
-				player = decryptTestPlayer(player)
+				testing.DecryptTestPlayer(GetEncryptionKey(), player)
 
 				Expect(playerDetails["name"]).To(Equal(player.Name))
 
@@ -542,7 +543,7 @@ var _ = Describe("Player Model", func() {
 				denier := deniedMembership["denier"].(map[string]interface{})
 				Expect(denier["name"]).To(Equal(player.Name))
 
-				owner = decryptTestPlayer(owner)
+				testing.DecryptTestPlayer(GetEncryptionKey(), owner)
 
 				pendingInvite := playerDetails["memberships"].([]map[string]interface{})[14]
 				Expect(pendingInvite["requestor"]).NotTo(BeEquivalentTo(nil))

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/util"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 var _ = Describe("Player Model", func() {
@@ -70,6 +70,25 @@ var _ = Describe("Player Model", func() {
 				_, err := GetPlayerByID(testDb, -1)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Player was not found with id: -1"))
+			})
+
+			It("Should decrypt Player.Name", func() {
+				_, player, err := CreatePlayerFactory(testDb, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				encryptedName, err := util.EncryptData(player.Name, GetEncryptionKey())
+				Expect(err).NotTo(HaveOccurred())
+
+				name := player.Name
+				player.Name = encryptedName
+				count, err := testDb.Update(player)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(int(count)).To(Equal(1))
+
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dbPlayer.ID).To(Equal(player.ID))
+				Expect(dbPlayer.Name).To(Equal(name))
 			})
 		})
 

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -109,6 +109,25 @@ var _ = Describe("Player Model", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Player was not found with id: invalid-player"))
 			})
+
+			It("Should decrypt Player.Name", func() {
+				_, player, err := CreatePlayerFactory(testDb, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				encryptedName, err := util.EncryptData(player.Name, GetEncryptionKey())
+				Expect(err).NotTo(HaveOccurred())
+
+				name := player.Name
+				player.Name = encryptedName
+				count, err := testDb.Update(player)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(int(count)).To(Equal(1))
+
+				dbPlayer, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), player.GameID, player.PublicID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dbPlayer.ID).To(Equal(player.ID))
+				Expect(dbPlayer.Name).To(Equal(name))
+			})
 		})
 
 		Describe("Create Player", func() {

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -99,13 +99,13 @@ var _ = Describe("Player Model", func() {
 				_, player, err := CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				dbPlayer, err := GetPlayerByPublicID(testDb, player.GameID, player.PublicID)
+				dbPlayer, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), player.GameID, player.PublicID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.ID).To(Equal(player.ID))
 			})
 
 			It("Should not get non-existing Player by Game and Player", func() {
-				_, err := GetPlayerByPublicID(testDb, "invalid-game", "invalid-player")
+				_, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), "invalid-game", "invalid-player")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Player was not found with id: invalid-player"))
 			})
@@ -175,7 +175,7 @@ var _ = Describe("Player Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updPlayer.ID).To(Equal(player.ID))
 
-				dbPlayer, err := GetPlayerByPublicID(testDb, player.GameID, player.PublicID)
+				dbPlayer, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), player.GameID, player.PublicID)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(dbPlayer.Metadata["x"]).To(BeEquivalentTo(metadata["x"]))
@@ -202,7 +202,7 @@ var _ = Describe("Player Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updPlayer.ID).To(BeNumerically(">", 0))
 
-				dbPlayer, err := GetPlayerByPublicID(testDb, updPlayer.GameID, updPlayer.PublicID)
+				dbPlayer, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), updPlayer.GameID, updPlayer.PublicID)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(dbPlayer.Metadata).To(Equal(metadata))
@@ -230,6 +230,7 @@ var _ = Describe("Player Model", func() {
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
+					GetEncryptionKey(),
 					player.GameID,
 					player.PublicID,
 				)
@@ -311,6 +312,7 @@ var _ = Describe("Player Model", func() {
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
+					GetEncryptionKey(),
 					players[0].GameID,
 					players[0].PublicID,
 				)
@@ -357,6 +359,7 @@ var _ = Describe("Player Model", func() {
 
 				c, err := CreateClan(
 					testDb,
+					GetEncryptionKey(),
 					game.PublicID,
 					"johns-bug-clan",
 					"johns-bug-clan",
@@ -371,6 +374,7 @@ var _ = Describe("Player Model", func() {
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
+					GetEncryptionKey(),
 					players[0].GameID,
 					players[0].PublicID,
 				)
@@ -423,6 +427,7 @@ var _ = Describe("Player Model", func() {
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
+					GetEncryptionKey(),
 					players[0].GameID,
 					players[0].PublicID,
 				)
@@ -474,6 +479,7 @@ var _ = Describe("Player Model", func() {
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
+					GetEncryptionKey(),
 					player.GameID,
 					player.PublicID,
 				)
@@ -507,6 +513,7 @@ var _ = Describe("Player Model", func() {
 			It("Should return error if Player does not exist", func() {
 				playerDetails, err := GetPlayerDetails(
 					testDb,
+					GetEncryptionKey(),
 					"game-id",
 					"invalid-player-id",
 				)

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Player Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(player.ID).NotTo(Equal(0))
 
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(dbPlayer.GameID).To(Equal(player.GameID))
@@ -61,13 +61,15 @@ var _ = Describe("Player Model", func() {
 				_, player, err := CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.ID).To(Equal(player.ID))
+				Expect(dbPlayer.Name).To(Equal(player.Name))
 			})
 
 			It("Should not get non-existing Player", func() {
-				_, err := GetPlayerByID(testDb, -1)
+				_, err := GetPlayerByID(testDb, GetEncryptionKey(), -1)
+
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Player was not found with id: -1"))
 			})
@@ -118,6 +120,7 @@ var _ = Describe("Player Model", func() {
 				playerID := uuid.NewV4().String()
 				player, err := CreatePlayer(
 					testDb,
+					GetEncryptionKey(),
 					game.PublicID,
 					playerID,
 					"player-name",
@@ -127,7 +130,7 @@ var _ = Describe("Player Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(player.ID).NotTo(BeEquivalentTo(0))
 
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(dbPlayer.GameID).To(Equal(player.GameID))
@@ -143,6 +146,7 @@ var _ = Describe("Player Model", func() {
 				metadata := map[string]interface{}{"x": "a"}
 				updPlayer, err := UpdatePlayer(
 					testDb,
+					GetEncryptionKey(),
 					player.GameID,
 					player.PublicID,
 					player.Name,
@@ -169,6 +173,7 @@ var _ = Describe("Player Model", func() {
 				metadata := map[string]interface{}{"x": "1"}
 				updPlayer, err := UpdatePlayer(
 					testDb,
+					GetEncryptionKey(),
 					gameID,
 					publicID,
 					publicID,
@@ -187,6 +192,7 @@ var _ = Describe("Player Model", func() {
 			It("Should not update a Player with Invalid Data with UpdatePlayer", func() {
 				_, err := UpdatePlayer(
 					testDb,
+					GetEncryptionKey(),
 					"-1",
 					"qwe",
 					"some player name",
@@ -524,7 +530,7 @@ var _ = Describe("Player Model", func() {
 				err = UpdatePlayerMembershipCount(testDb, player.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(prevMemberships + 1))
 			})
@@ -544,7 +550,7 @@ var _ = Describe("Player Model", func() {
 				err = UpdatePlayerMembershipCount(testDb, player.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(prevMemberships - 1))
 			})
@@ -576,7 +582,7 @@ var _ = Describe("Player Model", func() {
 
 				err = UpdatePlayerOwnershipCount(testDb, player.ID)
 				Expect(err).NotTo(HaveOccurred())
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.OwnershipCount).To(Equal(1))
 			})
@@ -612,7 +618,7 @@ var _ = Describe("Player Model", func() {
 
 				err = UpdatePlayerOwnershipCount(testDb, player.ID)
 				Expect(err).NotTo(HaveOccurred())
-				dbPlayer, err := GetPlayerByID(testDb, player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.OwnershipCount).To(Equal(1))
 			})

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -3,7 +3,9 @@ package testing
 import (
 	"time"
 
+	. "github.com/onsi/gomega"
 	"github.com/topfreegames/khan/caches"
+	"github.com/topfreegames/khan/util"
 
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/topfreegames/extensions/v9/mongo/interfaces"
@@ -50,4 +52,22 @@ func GetTestClansSummariesCache(ttl, cleanupInterval time.Duration) *caches.Clan
 	return &caches.ClansSummaries{
 		Cache: gocache.New(ttl, cleanupInterval),
 	}
+}
+
+// DecryptTestPlayer decrypt player name and return the player decrypted
+func DecryptTestPlayer(encryptionKey []byte, player *models.Player) {
+	name, err := util.DecryptData(player.Name, encryptionKey)
+	Expect(err).NotTo(HaveOccurred())
+	player.Name = name
+}
+
+//UpdateEncryptingTestPlayer encrypt player name and save it to database
+func UpdateEncryptingTestPlayer(db models.DB, encryptionKey []byte, player *models.Player) {
+	name, err := util.EncryptData(player.Name, encryptionKey)
+	Expect(err).NotTo(HaveOccurred())
+	player.Name = name
+	rows, err := db.Update(player)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(rows).To(BeEquivalentTo(1))
+
 }

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -54,7 +54,7 @@ func GetTestClansSummariesCache(ttl, cleanupInterval time.Duration) *caches.Clan
 	}
 }
 
-// DecryptTestPlayer decrypt player name and return the player decrypted
+// DecryptTestPlayer replaces the encrypted name by the plain text name in the player object
 func DecryptTestPlayer(encryptionKey []byte, player *models.Player) {
 	name, err := util.DecryptData(player.Name, encryptionKey)
 	Expect(err).NotTo(HaveOccurred())

--- a/util/errors.go
+++ b/util/errors.go
@@ -1,0 +1,9 @@
+package util
+
+type TokenSizeError struct {
+	Msg string
+}
+
+func (t *TokenSizeError) Error() string {
+	return t.Msg
+}

--- a/util/secure.go
+++ b/util/secure.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/wildlife-studios/crypto"
+)
+
+//EncryptData is a func that use wildlife crypto module to cipher the data
+// the key must have 32 bytes length
+func EncryptData(data string, key []byte) (string, error) {
+	if len(key) != 32 {
+		return "", &TokenSizeError{Msg: "The key length is different than 32"}
+	}
+
+	xChacha := crypto.NewXChacha()
+	encrypted, err := xChacha.Encrypt([]byte(data), key)
+	if err != nil {
+		return "", err
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(encrypted)
+
+	return encoded, nil
+}
+
+//DecryptData is a func that use wildlife crypto to decipher the data
+// the key must have 32 bytes length
+func DecryptData(encodedData string, key []byte) (string, error) {
+	if len(key) != 32 {
+		return "", &TokenSizeError{Msg: "The key length is different than 32"}
+	}
+
+	cipheredData, err := base64.StdEncoding.DecodeString(encodedData)
+	if err != nil {
+		return "", err
+	}
+
+	xChacha := crypto.NewXChacha()
+	data, err := xChacha.Decrypt([]byte(cipheredData), key)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s", data), nil
+}

--- a/util/secure_test.go
+++ b/util/secure_test.go
@@ -1,4 +1,4 @@
-package util
+package util_test
 
 import (
 	"encoding/base64"
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	. "github.com/topfreegames/khan/util"
 	"github.com/wildlife-studios/crypto"
 )
 
@@ -17,14 +18,16 @@ var _ = Describe("Security package", func() {
 	Describe("EncryptData", func() {
 		It("Should encrypt with XChacha and encode to base64", func() {
 			xChacha := crypto.NewXChacha()
-			encrypted, err := xChacha.Encrypt([]byte(data), encryptionKey[:32])
-			Expect(err).NotTo(HaveOccurred())
 
 			encryptedData, err := EncryptData(data, encryptionKey[:32])
 			Expect(err).NotTo(HaveOccurred())
 
-			encoded := base64.StdEncoding.EncodeToString(encrypted)
-			Expect(encryptedData).To(Equal(encoded))
+			decoded, err := base64.StdEncoding.DecodeString(encryptedData)
+			Expect(err).NotTo(HaveOccurred())
+
+			decryptedData, err := xChacha.Decrypt([]byte(decoded), encryptionKey[:32])
+
+			Expect(data).To(Equal(string(decryptedData)))
 
 		})
 
@@ -51,7 +54,7 @@ var _ = Describe("Security package", func() {
 
 	Describe("DecryptData", func() {
 		It("Should decode with base64 after decrypt with XChacha", func() {
-			encryptedData, err := EncryptData(data, encryptionKey)
+			encryptedData, err := EncryptData(data, encryptionKey[:32])
 			Expect(err).NotTo(HaveOccurred())
 
 			cipheredData, err := base64.StdEncoding.DecodeString(encryptedData)

--- a/util/secure_test.go
+++ b/util/secure_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Security package", func() {
 			_, err := DecryptData(data, encryptionKey[:31])
 			Expect(err).To(HaveOccurred())
 
-			if _, ok := err.(*errors.TokenSizeError); !ok {
+			if _, ok := err.(*TokenSizeError); !ok {
 				Fail("Error is not TokenSizeError")
 			}
 
@@ -82,7 +82,7 @@ var _ = Describe("Security package", func() {
 			_, err = DecryptData(data, encryptionKey[:33])
 			Expect(err).To(HaveOccurred())
 
-			if _, ok := err.(*errors.TokenSizeError); !ok {
+			if _, ok := err.(*TokenSizeError); !ok {
 				Fail("Error is not TokenSizeError")
 			}
 

--- a/util/secure_test.go
+++ b/util/secure_test.go
@@ -1,0 +1,92 @@
+package util
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/wildlife-studios/crypto"
+)
+
+var encryptionKey []byte = []byte("a91j39s833hncy61alp0qb6e0s72pql14")
+var data string = "some_data_test"
+
+var _ = Describe("Security package", func() {
+	Describe("EncryptData", func() {
+		It("Should encrypt with XChacha and encode to base64", func() {
+			xChacha := crypto.NewXChacha()
+			encrypted, err := xChacha.Encrypt([]byte(data), encryptionKey[:32])
+			Expect(err).NotTo(HaveOccurred())
+
+			encryptedData, err := EncryptData(data, encryptionKey[:32])
+			Expect(err).NotTo(HaveOccurred())
+
+			encoded := base64.StdEncoding.EncodeToString(encrypted)
+			Expect(encryptedData).To(Equal(encoded))
+
+		})
+
+		It("Should return in error case encryptionKey length is different than 32 bytes", func() {
+			_, err := EncryptData(data, encryptionKey[:31])
+			Expect(err).To(HaveOccurred())
+
+			if _, ok := err.(*TokenSizeError); !ok {
+				Fail("Error is not TokenSizeError")
+			}
+
+			Expect(err.Error()).To(Equal("The key length is different than 32"))
+
+			_, err = EncryptData(data, encryptionKey[:33])
+			Expect(err).To(HaveOccurred())
+
+			if _, ok := err.(*TokenSizeError); !ok {
+				Fail("Error is not TokenSizeError")
+			}
+
+			Expect(err.Error()).To(Equal("The key length is different than 32"))
+		})
+	})
+
+	Describe("DecryptData", func() {
+		It("Should decode with base64 after decrypt with XChacha", func() {
+			encryptedData, err := EncryptData(data, encryptionKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			cipheredData, err := base64.StdEncoding.DecodeString(encryptedData)
+			Expect(err).NotTo(HaveOccurred())
+
+			xChacha := crypto.NewXChacha()
+			decrypted, err := xChacha.Decrypt([]byte(cipheredData), encryptionKey[:32])
+			Expect(err).NotTo(HaveOccurred())
+
+			decryptedData, err := DecryptData(encryptedData, encryptionKey[:32])
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(decryptedData).To(Equal(fmt.Sprintf("%s", decrypted)))
+			Expect(decryptedData).To(Equal(data))
+
+		})
+
+		It("Should return in error case encryptionKey length is less than 32 bytes", func() {
+			_, err := DecryptData(data, encryptionKey[:31])
+			Expect(err).To(HaveOccurred())
+
+			if _, ok := err.(*errors.TokenSizeError); !ok {
+				Fail("Error is not TokenSizeError")
+			}
+
+			Expect(err.Error()).To(Equal("The key length is different than 32"))
+
+			_, err = DecryptData(data, encryptionKey[:33])
+			Expect(err).To(HaveOccurred())
+
+			if _, ok := err.(*errors.TokenSizeError); !ok {
+				Fail("Error is not TokenSizeError")
+			}
+
+			Expect(err.Error()).To(Equal("The key length is different than 32"))
+		})
+	})
+})

--- a/util/util_suite_test.go
+++ b/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestKhan(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Khan Suite")
+}


### PR DESCRIPTION
Why
=======

The Khan saves player name as plain text on the database, what isn't compliance with the LGPD/GDPR laws. To be compliant with these laws now the Khan accepts a new environment variable `KHAN_SECURITY_ENCRYPTIONKEY` which should be a 32 byte length and will be used to encrypt the player name.

What was done
=======
* Create `security.encryptionKey` on app
* Refactor DAO to segmentize the player serialization field, in a way to concentrate the decryption logic in the `models/player.go`
* Add `util/secure.go` which will hold all encryption logic
* Add tests to `util/secure.go` in `util/secure_test.go`
* Add tests to routes that use the player name