### PR TITLE
Create script to encrypt player name

### DIFF
--- a/cmd/encryption_script.go
+++ b/cmd/encryption_script.go
@@ -1,0 +1,63 @@
+// khan
+// https://github.com/topfreegames/khan
+//
+// Licensed under the MIT license:
+// http://www.opensource.org/licenses/mit-license
+// Copyright © 2016 Top Free Games <backend@tfgco.com>
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/topfreegames/khan/log"
+	"github.com/topfreegames/khan/services"
+	"github.com/uber-go/zap"
+)
+
+var encryptionScriptDebug bool
+var encryptionScriptQuiet bool
+
+// encryptionScriptCmd represents the encryption script
+var encryptionScriptCmd = &cobra.Command{
+	Use:   "encryption-script",
+	Short: "start the khan encryption-scription script",
+	Long: `Starts khan encryption-scription script that encrypt player names.
+You can use environment variables to override configuration keys.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ll := zap.InfoLevel
+		if encryptionScriptDebug {
+			ll = zap.DebugLevel
+		}
+		if encryptionScriptQuiet {
+			ll = zap.ErrorLevel
+		}
+		logger := zap.New(
+			zap.NewJSONEncoder(), // drop timestamps in tests
+			ll,
+		)
+
+		cmdL := logger.With(
+			zap.String("source", "encryptionScriptCmd"),
+			zap.String("operation", "Run"),
+			zap.Bool("debug", encryptionScriptDebug),
+		)
+
+		log.D(cmdL, "Creating application...")
+		script := services.GetEncryptionScript(
+			ConfigFile,
+			encryptionScriptDebug,
+			logger,
+		)
+		log.D(cmdL, "Application created successfully.")
+
+		log.D(cmdL, "Starting script...")
+		script.Start()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(encryptionScriptCmd)
+
+	encryptionScriptCmd.Flags().BoolVarP(&encryptionScriptDebug, "debug", "d", false, "Debug mode")
+	encryptionScriptCmd.Flags().BoolVarP(&encryptionScriptQuiet, "quiet", "q", false, "Quiet mode (log level error)")
+}

--- a/models/helpers_test.go
+++ b/models/helpers_test.go
@@ -14,6 +14,7 @@ import (
 	workers "github.com/jrallison/go-workers"
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/viper"
+	egorp "github.com/topfreegames/extensions/v9/gorp/interfaces"
 	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/mongo"
@@ -22,7 +23,7 @@ import (
 )
 
 // GetTestDB returns a connection to the test database
-func GetTestDB() (models.DB, error) {
+func GetTestDB() (egorp.Database, error) {
 	return models.GetDB("localhost", "khan_test", 5433, "disable", "khan_test", "")
 }
 

--- a/models/player.go
+++ b/models/player.go
@@ -335,7 +335,6 @@ func ApplySecurityChanges(db egorp.Database, encryptionKey []byte, players []*Pl
 
 	trx, err := db.Begin()
 	if err != nil {
-		err = trx.Rollback()
 		return err
 	}
 

--- a/models/player.go
+++ b/models/player.go
@@ -317,10 +317,11 @@ func GetPlayersToEncrypt(db DB, encryptionKey []byte, amount int) ([]*Player, er
 	query := `SELECT p.*
 	FROM players p
 		LEFT JOIN encrypted_players ep ON p.id = ep.player_id
-	WHERE ep.player_id IS NULL`
+	WHERE ep.player_id IS NULL
+	LIMIT $1`
 
 	var players []*Player
-	_, err := db.Select(&players, query)
+	_, err := db.Select(&players, query, amount)
 	if err != nil {
 		return nil, err
 	}

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -1017,6 +1017,19 @@ var _ = Describe("Player Model", func() {
 				Expect(secondPlayerToEncrypt.PublicID).To(Equal(encryptedPlayer2.PublicID))
 				Expect(secondPlayerToEncrypt.ID).To(Equal(encryptedPlayer2.ID))
 			})
+
+			It("Should return the amount of players", func() {
+				_, _, err := CreatePlayerFactory(testDb, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				_, _, err = CreatePlayerFactory(testDb, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				playersToEncrypt, err := GetPlayersToEncrypt(testDb, GetEncryptionKey(), 1)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(playersToEncrypt)).To(Equal(1))
+			})
 		})
 
 		Describe("ApplySecurityChanges", func() {

--- a/services/encryption_script.go
+++ b/services/encryption_script.go
@@ -1,0 +1,197 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/viper"
+	gorp "github.com/topfreegames/extensions/v9/gorp/interfaces"
+	"github.com/topfreegames/khan/log"
+	"github.com/topfreegames/khan/models"
+	"github.com/uber-go/zap"
+)
+
+// EncryptionScript is a struct that represents a Khan API Application
+type EncryptionScript struct {
+	Debug         bool
+	ConfigPath    string
+	Config        *viper.Viper
+	Logger        zap.Logger
+	EncryptionKey []byte
+	db            gorp.Database
+}
+
+// GetEncryptionScript returns a new Khan API Application
+func GetEncryptionScript(configPath string, debug bool, logger zap.Logger) *EncryptionScript {
+	app := &EncryptionScript{
+		ConfigPath: configPath,
+		Config:     viper.New(),
+		Debug:      debug,
+		Logger:     logger,
+	}
+
+	app.Configure()
+	return app
+}
+
+// Configure instantiates the required dependencies for Khan Api Application
+func (app *EncryptionScript) Configure() {
+	app.setConfigurationDefaults()
+	app.loadConfiguration()
+	app.connectDatabase()
+}
+
+func (app *EncryptionScript) setConfigurationDefaults() {
+	l := app.Logger.With(
+		zap.String("source", "app"),
+		zap.String("operation", "setConfigurationDefaults"),
+	)
+	app.Config.SetDefault("graceperiod.ms", 500)
+	app.Config.SetDefault("postgres.host", "localhost")
+	app.Config.SetDefault("postgres.user", "khan")
+	app.Config.SetDefault("postgres.dbName", "khan")
+	app.Config.SetDefault("postgres.port", 5432)
+	app.Config.SetDefault("postgres.sslMode", "disable")
+	app.Config.SetDefault("security.encryptionKey", "00000000000000000000000000000000")
+	app.Config.SetDefault("script.tick", "1s")
+	app.Config.SetDefault("script.playerAmount", "500")
+
+	log.D(l, "Configuration defaults set.")
+}
+
+func (app *EncryptionScript) loadConfiguration() {
+	l := app.Logger.With(
+		zap.String("source", "app"),
+		zap.String("operation", "loadConfiguration"),
+		zap.String("configPath", app.ConfigPath),
+	)
+
+	app.Config.SetConfigType("yaml")
+	app.Config.SetConfigFile(app.ConfigPath)
+	app.Config.SetEnvPrefix("khan")
+	app.Config.AddConfigPath(".")
+	app.Config.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	app.Config.AutomaticEnv()
+
+	log.D(l, "Loading configuration file...")
+	if err := app.Config.ReadInConfig(); err == nil {
+		log.I(l, "Loaded config file successfully.")
+	} else {
+		log.P(l, "Config file failed to load.")
+	}
+
+	app.EncryptionKey = []byte(app.Config.GetString("security.encryptionKey"))
+}
+
+func (app *EncryptionScript) connectDatabase() {
+	host := app.Config.GetString("postgres.host")
+	user := app.Config.GetString("postgres.user")
+	dbName := app.Config.GetString("postgres.dbname")
+	password := app.Config.GetString("postgres.password")
+	port := app.Config.GetInt("postgres.port")
+	sslMode := app.Config.GetString("postgres.sslMode")
+
+	l := app.Logger.With(
+		zap.String("source", "app"),
+		zap.String("operation", "connectDatabase"),
+		zap.String("host", host),
+		zap.String("user", user),
+		zap.String("dbName", dbName),
+		zap.Int("port", port),
+		zap.String("sslMode", sslMode),
+	)
+
+	log.D(l, "Connecting to database...")
+
+	db, err := models.GetDB(host, user, port, sslMode, dbName, password)
+
+	if err != nil {
+		log.P(l, "Could not connect to postgres...", func(cm log.CM) {
+			cm.Write(zap.String("error", err.Error()))
+		})
+	}
+
+	_, err = db.SelectInt("select count(*) from games")
+	if err != nil {
+		log.P(l, "Could not connect to postgres...", func(cm log.CM) {
+			cm.Write(zap.String("error", err.Error()))
+		})
+	}
+
+	log.I(l, "Connected to database successfully.")
+	app.db = db
+}
+
+// Start starts listening for web requests at specified host and port
+func (app *EncryptionScript) Start() {
+	l := app.Logger.With(
+		zap.String("source", "app"),
+		zap.String("operation", "Start"),
+	)
+
+	sg := make(chan os.Signal)
+	stopScript := make(chan bool, 1)
+	signal.Notify(sg, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGKILL, syscall.SIGTERM)
+
+	go app.executeScript(stopScript)
+
+	// stop server
+	select {
+	case s := <-sg:
+		graceperiod := app.Config.GetInt("graceperiod.ms")
+		log.I(l, "shutting down", func(cm log.CM) {
+			cm.Write(zap.String("signal", fmt.Sprintf("%v", s)),
+				zap.Int("graceperiod", graceperiod))
+		})
+		stopScript <- true
+		time.Sleep(time.Duration(graceperiod) * time.Millisecond)
+	}
+	log.I(l, "app stopped")
+}
+
+func (app *EncryptionScript) executeScript(stopChan chan bool) {
+	ticker := time.NewTicker(app.Config.GetDuration("script.tick"))
+	for {
+		select {
+		case <-stopChan:
+			log.I(app.Logger, "Finishing script")
+		case <-ticker.C:
+			app.encryptPlayers()
+		}
+	}
+}
+
+func (app *EncryptionScript) encryptPlayers() {
+	logger := app.Logger.With(
+		zap.String("source", "app"),
+		zap.String("operation", "executeScript"),
+	)
+
+	amount := app.Config.GetInt("script.playerAmount")
+
+	initTime := time.Now()
+
+	players, err := models.GetPlayersToEncrypt(app.db, app.EncryptionKey, amount)
+	if err != nil {
+		log.E(logger, "error on get players to encrypt", func(cm log.CM) {
+			cm.Write(zap.Error(err))
+		})
+	}
+
+	if len(players) == 0 {
+		logger.Warn("FINISHED, there is no player to encrypt")
+		return
+	}
+
+	err = models.ApplySecurityChanges(app.db, app.EncryptionKey, players)
+	if err != nil {
+		log.E(logger, "error on update players", func(cm log.CM) {
+			cm.Write(zap.Error(err))
+		})
+	}
+	app.Logger.Debug("encryption done", zap.String("spent time", time.Since(initTime).String()))
+}

--- a/services/encryption_script.go
+++ b/services/encryption_script.go
@@ -180,6 +180,7 @@ func (app *EncryptionScript) encryptPlayers() {
 		log.E(logger, "error on get players to encrypt", func(cm log.CM) {
 			cm.Write(zap.Error(err))
 		})
+		return
 	}
 
 	if len(players) == 0 {
@@ -192,6 +193,8 @@ func (app *EncryptionScript) encryptPlayers() {
 		log.E(logger, "error on update players", func(cm log.CM) {
 			cm.Write(zap.Error(err))
 		})
+		return
 	}
+
 	app.Logger.Debug("encryption done", zap.String("spent time", time.Since(initTime).String()))
 }


### PR DESCRIPTION
WHY
=======

The Khan database has a lot of players with the name in plain text form. This PR has a script that based on the `encrypted_players` table executes encrypting the already mentioned field.

WHAT WAS DONE
=======
* Create `encryption-script` command
* Create `GetPlayersToEncrypt` and `ApplySecurityChanges` on models to be used by the script
* Create service EncryptionScript