### PR TITLE
Add transactions to write player

### DIFF
--- a/api/player.go
+++ b/api/player.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo"
+	"github.com/topfreegames/extensions/v9/gorp/interfaces"
 	"github.com/topfreegames/khan/log"
 	"github.com/topfreegames/khan/models"
 	"github.com/uber-go/zap"
@@ -24,8 +25,6 @@ func CreatePlayerHandler(app *App) func(c echo.Context) error {
 		c.Set("route", "CreatePlayer")
 		start := time.Now()
 		gameID := c.Param("gameID")
-
-		db := app.Db(c.StdContext())
 
 		logger := app.Logger.With(
 			zap.String("source", "playerHandler"),
@@ -44,11 +43,17 @@ func CreatePlayerHandler(app *App) func(c echo.Context) error {
 			return FailWith(http.StatusBadRequest, err.Error(), c)
 		}
 
+		var transaction interfaces.Transaction
+		transaction, err = app.BeginTrans(c.StdContext(), logger)
+		if err != nil {
+			return FailWith(http.StatusBadRequest, err.Error(), c)
+		}
+
 		var player *models.Player
 		err = WithSegment("player-create", c, func() error {
 			log.D(logger, "Creating player...")
 			player, err = models.CreatePlayer(
-				db,
+				transaction,
 				logger,
 				app.EncryptionKey,
 				gameID,
@@ -66,7 +71,16 @@ func CreatePlayerHandler(app *App) func(c echo.Context) error {
 			return nil
 		})
 		if err != nil {
+			errRollback := app.Rollback(transaction, "Player creation failed, rolling back", c, logger, err)
+			if errRollback != nil {
+				return FailWith(http.StatusInternalServerError, fmt.Sprint(err.Error(), ", rolback error: ", errRollback.Error()), c)
+			}
 			return FailWith(http.StatusInternalServerError, err.Error(), c)
+		}
+
+		err = app.Commit(transaction, "Player created successful", c, logger)
+		if err != nil {
+			return FailWith(500, err.Error(), c)
 		}
 
 		result := map[string]interface{}{
@@ -158,11 +172,17 @@ func UpdatePlayerHandler(app *App) func(c echo.Context) error {
 			return FailWith(http.StatusBadRequest, err.Error(), c)
 		}
 
+		var transaction interfaces.Transaction
+		transaction, err = app.BeginTrans(c.StdContext(), logger)
+		if err != nil {
+			return FailWith(http.StatusBadRequest, err.Error(), c)
+		}
+
 		err = WithSegment("player-update", c, func() error {
 			err = WithSegment("player-update-query", c, func() error {
 				log.D(logger, "Updating player...")
 				player, err = models.UpdatePlayer(
-					db,
+					transaction,
 					logger,
 					app.EncryptionKey,
 					gameID,
@@ -182,7 +202,16 @@ func UpdatePlayerHandler(app *App) func(c echo.Context) error {
 			return nil
 		})
 		if err != nil {
+			errRollback := app.Rollback(transaction, "Player update failed, rolling back", c, logger, err)
+			if errRollback != nil {
+				return FailWith(http.StatusInternalServerError, fmt.Sprint(err.Error(), ", rolback error: ", errRollback.Error()), c)
+			}
 			return FailWith(http.StatusInternalServerError, err.Error(), c)
+		}
+
+		err = app.Commit(transaction, "Player created successful", c, logger)
+		if err != nil {
+			return FailWith(500, err.Error(), c)
 		}
 
 		err = WithSegment("hook-dispatch", c, func() error {

--- a/api/player.go
+++ b/api/player.go
@@ -46,7 +46,7 @@ func CreatePlayerHandler(app *App) func(c echo.Context) error {
 		var transaction interfaces.Transaction
 		transaction, err = app.BeginTrans(c.StdContext(), logger)
 		if err != nil {
-			return FailWith(http.StatusBadRequest, err.Error(), c)
+			return FailWith(http.StatusInternalServerError, err.Error(), c)
 		}
 
 		var player *models.Player
@@ -80,7 +80,7 @@ func CreatePlayerHandler(app *App) func(c echo.Context) error {
 
 		err = app.Commit(transaction, "Player created successful", c, logger)
 		if err != nil {
-			return FailWith(500, err.Error(), c)
+			return FailWith(http.StatusInternalServerError, err.Error(), c)
 		}
 
 		result := map[string]interface{}{
@@ -175,7 +175,7 @@ func UpdatePlayerHandler(app *App) func(c echo.Context) error {
 		var transaction interfaces.Transaction
 		transaction, err = app.BeginTrans(c.StdContext(), logger)
 		if err != nil {
-			return FailWith(http.StatusBadRequest, err.Error(), c)
+			return FailWith(http.StatusInternalServerError, err.Error(), c)
 		}
 
 		err = WithSegment("player-update", c, func() error {
@@ -211,7 +211,7 @@ func UpdatePlayerHandler(app *App) func(c echo.Context) error {
 
 		err = app.Commit(transaction, "Player created successful", c, logger)
 		if err != nil {
-			return FailWith(500, err.Error(), c)
+			return FailWith(http.StatusInternalServerError, err.Error(), c)
 		}
 
 		err = WithSegment("hook-dispatch", c, func() error {


### PR DESCRIPTION
WHY
========

The write flows were done without transactions, which don't guarantee to each player that was encrypted another EncryptedPlayer is created. To ensure it, this PR proposes to add transactions to player write flows.

WHAT WAS DONE
========
* Add transaction to CreatePlayer
* Add transaction to UpdatePlayer