### PR TITLE
Fix flaky test

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -573,11 +573,6 @@ func (app *App) StartWorkers() {
 	workers.Run()
 }
 
-//NonblockingStartWorkers non-blocking
-func (app *App) NonblockingStartWorkers() {
-	workers.Start()
-}
-
 func (app *App) initESWorker() {
 	logger := app.Logger.With(
 		zap.String("source", "app"),

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -63,6 +63,7 @@ var _ = Describe("API Application", func() {
 		var err error
 		testDb, err = GetTestDB()
 		Expect(err).NotTo(HaveOccurred())
+		fixtures.ConfigureAndStartGoWorkers()
 	})
 
 	Describe("App Struct", func() {
@@ -81,7 +82,6 @@ var _ = Describe("API Application", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			app := GetDefaultTestApp()
-			app.NonblockingStartWorkers()
 
 			appGame, err := app.GetGame(nil, game.PublicID)
 			Expect(err).NotTo(HaveOccurred())
@@ -94,7 +94,6 @@ var _ = Describe("API Application", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			app := GetDefaultTestApp()
-			app.NonblockingStartWorkers()
 
 			appGame, err := app.GetGame(nil, game.PublicID)
 			Expect(err).NotTo(HaveOccurred())
@@ -110,7 +109,6 @@ var _ = Describe("API Application", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			app := GetDefaultTestApp()
-			app.NonblockingStartWorkers()
 
 			hooks := app.GetHooks(context.Background())
 			Expect(len(hooks[gameID])).To(Equal(2))
@@ -129,7 +127,6 @@ var _ = Describe("API Application", func() {
 			responses := startRouteHandler([]string{"/created", "/created2"}, 52525)
 
 			app := GetDefaultTestApp()
-			app.NonblockingStartWorkers()
 
 			resultingPayload := map[string]interface{}{
 				"success":  true,
@@ -156,7 +153,6 @@ var _ = Describe("API Application", func() {
 			)
 
 			app := GetDefaultTestApp()
-			app.NonblockingStartWorkers()
 
 			resultingPayload := map[string]interface{}{
 				"url":      "http://some-url.com",
@@ -191,7 +187,6 @@ var _ = Describe("API Application", func() {
 			responses := startRouteHandler([]string{fmt.Sprintf("/created/%s", hooks[0].GameID)}, 52525)
 
 			app := GetDefaultTestApp()
-			app.NonblockingStartWorkers()
 
 			resultingPayload := map[string]interface{}{
 				"success":  true,
@@ -215,7 +210,6 @@ var _ = Describe("API Application", func() {
 			responses := startRouteHandler([]string{fmt.Sprintf("/1/créated/%s", hooks[0].GameID)}, 52525)
 
 			app := GetDefaultTestApp()
-			app.NonblockingStartWorkers()
 
 			resultingPayload := map[string]interface{}{
 				"success":        true,
@@ -242,7 +236,6 @@ var _ = Describe("API Application", func() {
 			responses := startRouteHandler([]string{fmt.Sprintf("/invalid-webhook-request/%s", hooks[0].GameID)}, 52525)
 
 			app := GetDefaultTestApp()
-			app.NonblockingStartWorkers()
 
 			resultingPayload := map[string]interface{}{
 				"success": true,

--- a/api/app_test.go
+++ b/api/app_test.go
@@ -20,6 +20,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	. "github.com/topfreegames/khan/api"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	kt "github.com/topfreegames/khan/testing"
 )
 
@@ -75,7 +76,7 @@ var _ = Describe("API Application", func() {
 
 	Describe("App Games", func() {
 		It("should load all games", func() {
-			game := models.GameFactory.MustCreate().(*models.Game)
+			game := fixtures.GameFactory.MustCreate().(*models.Game)
 			err := testDb.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -88,7 +89,7 @@ var _ = Describe("API Application", func() {
 		})
 
 		It("should get game by Public ID", func() {
-			game := models.GameFactory.MustCreate().(*models.Game)
+			game := fixtures.GameFactory.MustCreate().(*models.Game)
 			err := testDb.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -105,7 +106,7 @@ var _ = Describe("API Application", func() {
 	Describe("App Load Hooks", func() {
 		It("should load all hooks", func() {
 			gameID := uuid.NewV4().String()
-			_, err := models.GetTestHooks(testDb, gameID, 2)
+			_, err := fixtures.GetTestHooks(testDb, gameID, 2)
 			Expect(err).NotTo(HaveOccurred())
 
 			app := GetDefaultTestApp()
@@ -120,7 +121,7 @@ var _ = Describe("API Application", func() {
 
 	Describe("App Dispatch Hook", func() {
 		It("should dispatch hooks", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/created",
 				"http://localhost:52525/created2",
 			}, models.GameUpdatedHook)
@@ -143,7 +144,7 @@ var _ = Describe("API Application", func() {
 		})
 
 		It("should encode hook parameters", func() {
-			hooks, err := models.GetHooksForRoutes(
+			hooks, err := fixtures.GetHooksForRoutes(
 				testDb, []string{
 					"http://localhost:52525/encoding?url={{url}}",
 				}, models.GameUpdatedHook,
@@ -183,7 +184,7 @@ var _ = Describe("API Application", func() {
 		})
 
 		It("should dispatch hooks using template", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/created/{{publicID}}",
 			}, models.GameUpdatedHook)
 			Expect(err).NotTo(HaveOccurred())
@@ -207,7 +208,7 @@ var _ = Describe("API Application", func() {
 		})
 
 		It("should dispatch hooks using second-level key", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/{{playerPosition}}/créated/{{player.publicID}}",
 			}, models.GameUpdatedHook)
 			Expect(err).NotTo(HaveOccurred())
@@ -234,7 +235,7 @@ var _ = Describe("API Application", func() {
 		})
 
 		It("should fail dispatch hooks if invalid key", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/invalid-webhook-request/{{player.publicID.invalid}}",
 			}, models.GameUpdatedHook)
 			Expect(err).NotTo(HaveOccurred())

--- a/api/clan_test.go
+++ b/api/clan_test.go
@@ -24,21 +24,23 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/api"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	"github.com/topfreegames/khan/testing"
 )
 
 var _ = Describe("Clan API Handler", func() {
 	var testDb, db models.DB
-	var a *api.App
+	var app *api.App
 
 	BeforeEach(func() {
 		var err error
 		testDb, err = GetTestDB()
 		Expect(err).NotTo(HaveOccurred())
 
-		a = GetDefaultTestApp()
-		db = a.Db(nil)
-		a.NonblockingStartWorkers()
+		app = GetDefaultTestApp()
+		db = app.Db(nil)
+
+		app.NonblockingStartWorkers()
 	})
 
 	AfterEach(func() {
@@ -47,7 +49,7 @@ var _ = Describe("Clan API Handler", func() {
 
 	Describe("Create Clan Handler", func() {
 		It("Should create clan", func() {
-			_, player, err := models.CreatePlayerFactory(testDb, "")
+			_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clanPublicID := randomdata.FullName(randomdata.RandomGender)
@@ -59,7 +61,7 @@ var _ = Describe("Clan API Handler", func() {
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
-			status, body := PostJSON(a, GetGameRoute(player.GameID, "/clans"), payload)
+			status, body := PostJSON(app, GetGameRoute(player.GameID, "/clans"), payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -83,7 +85,7 @@ var _ = Describe("Clan API Handler", func() {
 		It("Should create clan into mongodb if its configured", func() {
 			mongo, err := GetTestMongo()
 			Expect(err).NotTo(HaveOccurred())
-			_, player, err := models.CreatePlayerFactory(testDb, "")
+			_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			metadata := map[string]interface{}{"x": "a"}
@@ -97,7 +99,7 @@ var _ = Describe("Clan API Handler", func() {
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
-			status, body := PostJSON(a, GetGameRoute(player.GameID, "/clans"), payload)
+			status, body := PostJSON(app, GetGameRoute(player.GameID, "/clans"), payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -126,7 +128,7 @@ var _ = Describe("Clan API Handler", func() {
 		// TODO: fix this when hardcoded boomforce is removed
 		XIt("Should index clan into ES when created", func() {
 			es := GetTestES()
-			_, player, err := models.CreatePlayerFactory(testDb, "")
+			_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clanPublicID := randomdata.FullName(randomdata.RandomGender)
@@ -138,7 +140,7 @@ var _ = Describe("Clan API Handler", func() {
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
-			status, body := PostJSON(a, GetGameRoute(player.GameID, "/clans"), payload)
+			status, body := PostJSON(app, GetGameRoute(player.GameID, "/clans"), payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -162,7 +164,7 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should not create clan if missing parameters", func() {
-			_, player, err := models.CreatePlayerFactory(testDb, "")
+			_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clanPublicID := randomdata.FullName(randomdata.RandomGender)
@@ -171,7 +173,7 @@ var _ = Describe("Clan API Handler", func() {
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
-			status, body := PostJSON(a, GetGameRoute(player.GameID, "/clans"), payload)
+			status, body := PostJSON(app, GetGameRoute(player.GameID, "/clans"), payload)
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			var result map[string]interface{}
@@ -182,7 +184,7 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should not create clan if invalid payload", func() {
 			gameID := "gameID"
-			status, body := Post(a, GetGameRoute(gameID, "/clans"), "invalid")
+			status, body := Post(app, GetGameRoute(gameID, "/clans"), "invalid")
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			var result map[string]interface{}
@@ -192,7 +194,7 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should not create clan if owner does not exist", func() {
-			game, _, err := models.CreatePlayerFactory(testDb, "")
+			game, _, err := fixtures.CreatePlayerFactory(testDb, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			payload := map[string]interface{}{
@@ -203,7 +205,7 @@ var _ = Describe("Clan API Handler", func() {
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
-			status, body := PostJSON(a, GetGameRoute(game.PublicID, "/clans"), payload)
+			status, body := PostJSON(app, GetGameRoute(game.PublicID, "/clans"), payload)
 
 			Expect(status).To(Equal(http.StatusNotFound))
 			var result map[string]interface{}
@@ -213,7 +215,7 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should not create clan if invalid data", func() {
-			_, player, err := models.CreatePlayerFactory(testDb, "")
+			_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			payload := map[string]interface{}{
@@ -224,7 +226,7 @@ var _ = Describe("Clan API Handler", func() {
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
-			status, body := PostJSON(a, GetGameRoute(player.GameID, "/clans"), payload)
+			status, body := PostJSON(app, GetGameRoute(player.GameID, "/clans"), payload)
 
 			Expect(status).To(Equal(http.StatusInternalServerError))
 			var result map[string]interface{}
@@ -236,11 +238,11 @@ var _ = Describe("Clan API Handler", func() {
 
 	Describe("Leave Clan Handler", func() {
 		It("Should leave a clan and transfer ownership", func() {
-			_, clan, owner, players, memberships, err := models.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+			_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			route := GetGameRoute(clan.GameID, fmt.Sprintf("clans/%s/leave", clan.PublicID))
-			status, body := PostJSON(a, route, map[string]interface{}{})
+			status, body := PostJSON(app, route, map[string]interface{}{})
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -262,7 +264,7 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should not leave a clan if invalid clan", func() {
 			route := GetGameRoute("game-id", fmt.Sprintf("clans/%s/leave", "random-id"))
-			status, body := Post(a, route, "")
+			status, body := Post(app, route, "")
 
 			Expect(status).To(Equal(http.StatusNotFound))
 			var result map[string]interface{}
@@ -274,7 +276,7 @@ var _ = Describe("Clan API Handler", func() {
 
 	Describe("Transfer Clan Ownership Handler", func() {
 		It("Should transfer a clan ownership", func() {
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 			ownerPublicID := owner.PublicID
 			playerPublicID := players[0].PublicID
@@ -284,7 +286,7 @@ var _ = Describe("Clan API Handler", func() {
 				"playerPublicID": playerPublicID,
 			}
 			route := GetGameRoute(clan.GameID, fmt.Sprintf("clans/%s/transfer-ownership", clan.PublicID))
-			status, body := PostJSON(a, route, payload)
+			status, body := PostJSON(app, route, payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -298,7 +300,7 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should not transfer a clan ownership if missing parameters", func() {
 			route := GetGameRoute("game-id", fmt.Sprintf("clans/%s/transfer-ownership", "public-id"))
-			status, body := PostJSON(a, route, map[string]interface{}{})
+			status, body := PostJSON(app, route, map[string]interface{}{})
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			var result map[string]interface{}
@@ -310,7 +312,7 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should not transfer a clan ownership if invalid payload", func() {
 			route := GetGameRoute("game-id", fmt.Sprintf("clans/%s/transfer-ownership", "random-id"))
-			status, body := Post(a, route, "invalid")
+			status, body := Post(app, route, "invalid")
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			var result map[string]interface{}
@@ -322,7 +324,7 @@ var _ = Describe("Clan API Handler", func() {
 
 	Describe("Update Clan Handler", func() {
 		It("Should update clan", func() {
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -339,7 +341,7 @@ var _ = Describe("Clan API Handler", func() {
 				"autoJoin":         !clan.AutoJoin,
 			}
 			route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
-			status, body := PutJSON(a, route, payload)
+			status, body := PutJSON(app, route, payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -360,7 +362,7 @@ var _ = Describe("Clan API Handler", func() {
 		It("Should update Mongo if update clan", func() {
 			mongo, err := GetTestMongo()
 			Expect(err).NotTo(HaveOccurred())
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -395,7 +397,7 @@ var _ = Describe("Clan API Handler", func() {
 				"autoJoin":         !clan.AutoJoin,
 			}
 			route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", clan.PublicID))
-			status, body := PutJSON(a, route, payload)
+			status, body := PutJSON(app, route, payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -419,7 +421,7 @@ var _ = Describe("Clan API Handler", func() {
 		XIt("Should update ES if update clan", func() {
 			es := GetTestES()
 
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -442,7 +444,7 @@ var _ = Describe("Clan API Handler", func() {
 				"autoJoin":         !clan.AutoJoin,
 			}
 			route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
-			status, body := PutJSON(a, route, payload)
+			status, body := PutJSON(app, route, payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -485,7 +487,7 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should not update clan if missing parameters", func() {
 			route := GetGameRoute("gameID", fmt.Sprintf("/clans/%s", "publicID"))
-			status, body := PutJSON(a, route, map[string]interface{}{})
+			status, body := PutJSON(app, route, map[string]interface{}{})
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			var result map[string]interface{}
@@ -497,7 +499,7 @@ var _ = Describe("Clan API Handler", func() {
 		It("Should not update clan if invalid payload", func() {
 			route := GetGameRoute("game-id", fmt.Sprintf("/clans/%s", "random-id"))
 
-			status, body := Put(a, route, "invalid")
+			status, body := Put(app, route, "invalid")
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			var result map[string]interface{}
@@ -507,7 +509,7 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should not update clan if player is not the owner", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -523,7 +525,7 @@ var _ = Describe("Clan API Handler", func() {
 			}
 			route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
 
-			status, body := PutJSON(a, route, payload)
+			status, body := PutJSON(app, route, payload)
 
 			Expect(status).To(Equal(http.StatusNotFound))
 			var result map[string]interface{}
@@ -533,7 +535,7 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should not update clan if invalid data", func() {
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -548,7 +550,7 @@ var _ = Describe("Clan API Handler", func() {
 			}
 			route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
 
-			status, body := PutJSON(a, route, payload)
+			status, body := PutJSON(app, route, payload)
 
 			Expect(status).To(Equal(http.StatusInternalServerError))
 			var result map[string]interface{}
@@ -560,11 +562,11 @@ var _ = Describe("Clan API Handler", func() {
 
 	Describe("List All Clans Handler", func() {
 		It("Should get all clans", func() {
-			player, expectedClans, err := models.GetTestClans(testDb, "", "", 10)
+			player, expectedClans, err := fixtures.CreateTestClans(testDb, "", "", 10, nil)
 			Expect(err).NotTo(HaveOccurred())
 			sort.Sort(models.ClanByName(expectedClans))
 
-			status, body := Get(a, GetGameRoute(player.GameID, "/clans"))
+			status, body := Get(app, GetGameRoute(player.GameID, "/clans"))
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -586,7 +588,7 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should return empty list if invalid game query", func() {
-			status, body := Get(a, GetGameRoute("invalid-query-game-id", "/clans"))
+			status, body := Get(app, GetGameRoute("invalid-query-game-id", "/clans"))
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -599,10 +601,10 @@ var _ = Describe("Clan API Handler", func() {
 
 	Describe("Retrieve Clan Handler", func() {
 		It("Should get details for clan", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -619,10 +621,10 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should get details for clan with short publicID", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?shortID=true", clan.PublicID[0:8])))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?shortID=true", clan.PublicID[0:8])))
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -640,12 +642,12 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should get clan members", func() {
 			gameID := uuid.NewV4().String()
-			_, clan, _, _, _, err := models.GetClanWithMemberships(
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(
 				testDb, 10, 0, 0, 0, gameID, "clan-details-api-clan",
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -657,60 +659,60 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should fail with 400 if maxPendingApplications cannot be parsed as uint", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=xablau", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=xablau", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			Expect(body).To(ContainSubstring("invalid syntax"))
 		})
 
 		It("Should fail with 400 if maxPendingApplications is above allowed", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=101", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=101", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			Expect(body).To(ContainSubstring("above allowed"))
 		})
 
 		It("Should fail with 400 if maxPendingInvites cannot be parsed as uint", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=xablau", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=xablau", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			Expect(body).To(ContainSubstring("invalid syntax"))
 		})
 
 		It("Should fail with 400 if maxPendingInvites is above allowed", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=101", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=101", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			Expect(body).To(ContainSubstring("above allowed"))
 		})
 
 		It("Should fail with 400 if pendingApplicationsOrder is not a valid order string", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?pendingApplicationsOrder=xablau", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?pendingApplicationsOrder=xablau", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			Expect(body).To(ContainSubstring("order is invalid"))
 		})
 
 		It("Should fail with 400 if pendingInvitesOrder is not a valid order string", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?pendingInvitesOrder=xablau", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?pendingInvitesOrder=xablau", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusBadRequest))
 			Expect(body).To(ContainSubstring("order is invalid"))
@@ -732,10 +734,10 @@ var _ = Describe("Clan API Handler", func() {
 		}
 
 		It("should get pending applications even if max amount is not set", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, false, true)
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, false, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s", clan.PublicID)))
 			Expect(status).To(Equal(http.StatusOK))
 
 			var result retrieveClanPayload
@@ -745,10 +747,10 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("should get pending invites even if max amount is not set", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, true, true)
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, true, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s", clan.PublicID)))
 			Expect(status).To(Equal(http.StatusOK))
 
 			var result retrieveClanPayload
@@ -782,60 +784,60 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should get newest pending applications if order is not set", func() {
 			maxPending := 7
-			_, clan, _, _, memberships, err := models.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, false, true)
+			_, clan, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, false, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=%v", clan.PublicID, maxPending)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=%v", clan.PublicID, maxPending)))
 			Expect(status).To(Equal(http.StatusOK))
 			validateRetrieveClanResponse(memberships, body, ">", maxPending, false)
 		})
 
 		It("Should get newest pending applications", func() {
 			maxPending := 7
-			_, clan, _, _, memberships, err := models.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, false, true)
+			_, clan, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, false, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=%v&pendingApplicationsOrder=newest", clan.PublicID, maxPending)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=%v&pendingApplicationsOrder=newest", clan.PublicID, maxPending)))
 			Expect(status).To(Equal(http.StatusOK))
 			validateRetrieveClanResponse(memberships, body, ">", maxPending, false)
 		})
 
 		It("Should get oldest pending applications", func() {
 			maxPending := 7
-			_, clan, _, _, memberships, err := models.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, false, true)
+			_, clan, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, false, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=%v&pendingApplicationsOrder=oldest", clan.PublicID, maxPending)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingApplications=%v&pendingApplicationsOrder=oldest", clan.PublicID, maxPending)))
 			Expect(status).To(Equal(http.StatusOK))
 			validateRetrieveClanResponse(memberships, body, "<", maxPending, false)
 		})
 
 		It("Should get newest pending invites if order is not set", func() {
 			maxPending := 7
-			_, clan, _, _, memberships, err := models.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, true, true)
+			_, clan, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, true, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=%v", clan.PublicID, maxPending)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=%v", clan.PublicID, maxPending)))
 			Expect(status).To(Equal(http.StatusOK))
 			validateRetrieveClanResponse(memberships, body, ">", maxPending, true)
 		})
 
 		It("Should get newest pending invites", func() {
 			maxPending := 7
-			_, clan, _, _, memberships, err := models.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, true, true)
+			_, clan, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, true, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=%v&pendingInvitesOrder=newest", clan.PublicID, maxPending)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=%v&pendingInvitesOrder=newest", clan.PublicID, maxPending)))
 			Expect(status).To(Equal(http.StatusOK))
 			validateRetrieveClanResponse(memberships, body, ">", maxPending, true)
 		})
 
 		It("Should get oldest pending invites", func() {
 			maxPending := 7
-			_, clan, _, _, memberships, err := models.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, true, true)
+			_, clan, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 10, 0, 0, 10, "", "", false, true, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=%v&pendingInvitesOrder=oldest", clan.PublicID, maxPending)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s?maxPendingInvites=%v&pendingInvitesOrder=oldest", clan.PublicID, maxPending)))
 			Expect(status).To(Equal(http.StatusOK))
 			validateRetrieveClanResponse(memberships, body, "<", maxPending, true)
 		})
@@ -844,9 +846,9 @@ var _ = Describe("Clan API Handler", func() {
 	Describe("Retrieve Clan Members Handler", func() {
 		It("Should get clans player ids", func() {
 			gameID := uuid.NewV4().String()
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 10, 0, 0, 0, gameID, "clan1")
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 10, 0, 0, 0, gameID, "clan1")
 			Expect(err).NotTo(HaveOccurred())
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s/members", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s/members", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -866,11 +868,11 @@ var _ = Describe("Clan API Handler", func() {
 	Describe("Retrieve Clans Handler", func() {
 		It("Should get details for clans", func() {
 			gameID := uuid.NewV4().String()
-			_, clan1, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan1")
+			_, clan1, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan1")
 			Expect(err).NotTo(HaveOccurred())
-			_, clan2, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan2", true)
+			_, clan2, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan2", true)
 			Expect(err).NotTo(HaveOccurred())
-			_, clan3, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan3", true)
+			_, clan3, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan3", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clanIDs := []string{clan1.PublicID, clan2.PublicID, clan3.PublicID}
@@ -880,7 +882,7 @@ var _ = Describe("Clan API Handler", func() {
 				GetGameRoute(clan1.GameID, "clans-summary"),
 				strings.Join(clanIDs, ","),
 			)
-			status, body := Get(a, url)
+			status, body := Get(app, url)
 			Expect(status).To(Equal(http.StatusOK))
 
 			var result map[string]interface{}
@@ -913,7 +915,7 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should not get details for clans for unexistent game", func() {
 			gameID := uuid.NewV4().String()
-			_, clan, _, _, _, err := models.GetClanWithMemberships(
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(
 				testDb, 10, 0, 0, 0, gameID, uuid.NewV4().String(),
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -925,7 +927,7 @@ var _ = Describe("Clan API Handler", func() {
 				GetGameRoute("unexistent_game", "clans-summary"),
 				strings.Join(clanIDs, ","),
 			)
-			status, body := Get(a, url)
+			status, body := Get(app, url)
 
 			var result map[string]interface{}
 			json.Unmarshal([]byte(body), &result)
@@ -939,10 +941,10 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should fail with 400 if empty query string", func() {
 			gameID := uuid.NewV4().String()
-			_, clan1, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, uuid.NewV4().String())
+			_, clan1, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, uuid.NewV4().String())
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan1.GameID, "clans-summary"))
+			status, body := Get(app, GetGameRoute(clan1.GameID, "clans-summary"))
 			Expect(status).To(Equal(http.StatusBadRequest))
 			var result map[string]interface{}
 			json.Unmarshal([]byte(body), &result)
@@ -952,11 +954,11 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should not fail if some clans do not exists", func() {
 			gameID := uuid.NewV4().String()
-			_, clan1, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan1")
+			_, clan1, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan1")
 			Expect(err).NotTo(HaveOccurred())
-			_, clan2, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan2", true)
+			_, clan2, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan2", true)
 			Expect(err).NotTo(HaveOccurred())
-			_, clan3, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan3", true)
+			_, clan3, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, "clan3", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clanIDs := []string{clan1.PublicID, clan2.PublicID, clan3.PublicID, "unexistent_clan", "unexistent_clan2"}
@@ -966,7 +968,7 @@ var _ = Describe("Clan API Handler", func() {
 				GetGameRoute(clan1.GameID, "clans-summary"),
 				strings.Join(clanIDs, ","),
 			)
-			status, body := Get(a, url)
+			status, body := Get(app, url)
 			Expect(status).To(Equal(http.StatusOK))
 
 			var result map[string]interface{}
@@ -1005,10 +1007,10 @@ var _ = Describe("Clan API Handler", func() {
 
 	Describe("Retrieve Clan Summary Handler", func() {
 		It("Should get details for clan", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s/summary", clan.PublicID)))
+			status, body := Get(app, GetGameRoute(clan.GameID, fmt.Sprintf("/clans/%s/summary", clan.PublicID)))
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -1028,7 +1030,7 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should not get details for clan that does not exist", func() {
-			status, body := Get(a, GetGameRoute("game-id", "/clans/dont-exist/summary"))
+			status, body := Get(app, GetGameRoute("game-id", "/clans/dont-exist/summary"))
 			Expect(status).To(Equal(http.StatusNotFound))
 			var result map[string]interface{}
 			json.Unmarshal([]byte(body), &result)
@@ -1040,8 +1042,8 @@ var _ = Describe("Clan API Handler", func() {
 	Describe("Search Clan Handler", func() {
 		It("Should search for a clan", func() {
 			gameID := uuid.NewV4().String()
-			player, expectedClans, err := models.GetTestClans(
-				testDb, gameID, "clan-apisearch-clan", 10,
+			player, expectedClans, err := fixtures.CreateTestClans(
+				testDb, gameID, "clan-apisearch-clan", 10, nil,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1051,7 +1053,7 @@ var _ = Describe("Clan API Handler", func() {
 			err = testing.CreateClanNameTextIndexInMongo(GetTestMongo, gameID)
 			Expect(err).NotTo(HaveOccurred())
 
-			status, body := Get(a, GetGameRoute(player.GameID, "clans/search?term=APISEARCH"))
+			status, body := Get(app, GetGameRoute(player.GameID, "clans/search?term=APISEARCH"))
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -1079,12 +1081,12 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should search for a clan by publicID", func() {
 			gameID := uuid.NewV4().String()
-			player, expectedClans, err := models.GetTestClans(
-				testDb, gameID, "clan-apisearch-clan", 10,
+			player, expectedClans, err := fixtures.CreateTestClans(
+				testDb, gameID, "clan-apisearch-clan", 10, nil,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(1000 * time.Millisecond)
-			status, body := Get(a, GetGameRoute(
+			status, body := Get(app, GetGameRoute(
 				player.GameID, fmt.Sprintf("clans/search?term=%s", expectedClans[3].PublicID),
 			))
 
@@ -1103,8 +1105,8 @@ var _ = Describe("Clan API Handler", func() {
 
 		It("Should unicode search for a clan", func() {
 			gameID := uuid.NewV4().String()
-			player, expectedClans, err := models.GetTestClans(
-				testDb, gameID, "clan-apisearch-clan", 10,
+			player, expectedClans, err := fixtures.CreateTestClans(
+				testDb, gameID, "clan-apisearch-clan", 10, nil,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1112,7 +1114,7 @@ var _ = Describe("Clan API Handler", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			url := "clans/search?term=💩clán-clan-APISEARCH"
-			status, body := Get(a, GetGameRoute(player.GameID, url))
+			status, body := Get(app, GetGameRoute(player.GameID, url))
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
 			json.Unmarshal([]byte(body), &result)
@@ -1140,13 +1142,13 @@ var _ = Describe("Clan API Handler", func() {
 
 	Describe("Clan Hooks", func() {
 		It("Should call create clan hook", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/clancreated",
 			}, models.ClanCreatedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/clancreated"}, 52525)
 
-			_, player, err := models.CreatePlayerFactory(testDb, hooks[0].GameID, true)
+			_, player, err := fixtures.CreatePlayerFactory(testDb, hooks[0].GameID, true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clanPublicID := uuid.NewV4().String()
@@ -1158,7 +1160,7 @@ var _ = Describe("Clan API Handler", func() {
 				"allowApplication": true,
 				"autoJoin":         true,
 			}
-			status, body := PostJSON(a, GetGameRoute(player.GameID, "/clans"), payload)
+			status, body := PostJSON(app, GetGameRoute(player.GameID, "/clans"), payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -1188,13 +1190,13 @@ var _ = Describe("Clan API Handler", func() {
 		Describe("Update Clan Hook", func() {
 			Describe("Without whitelist", func() {
 				It("Should not call update clan hook", func() {
-					hooks, err := models.GetHooksForRoutes(testDb, []string{
+					hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/clanupdated",
 					}, models.ClanUpdatedHook)
 					Expect(err).NotTo(HaveOccurred())
 					responses := startRouteHandler([]string{"/clanupdated"}, 52525)
 
-					_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+					_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 					Expect(err).NotTo(HaveOccurred())
 
 					gameID := clan.GameID
@@ -1211,7 +1213,7 @@ var _ = Describe("Clan API Handler", func() {
 						"autoJoin":         clan.AutoJoin,
 					}
 					route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
-					status, body := PutJSON(a, route, payload)
+					status, body := PutJSON(app, route, payload)
 
 					Expect(status).To(Equal(http.StatusOK))
 					var result map[string]interface{}
@@ -1226,7 +1228,7 @@ var _ = Describe("Clan API Handler", func() {
 
 			Describe("With whitelist", func() {
 				It("Should call update clan hook if field in whitelist", func() {
-					hooks, err := models.GetHooksForRoutes(testDb, []string{
+					hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/clanupdatedhookwhitelist",
 					}, models.ClanUpdatedHook)
 					Expect(err).NotTo(HaveOccurred())
@@ -1241,7 +1243,7 @@ var _ = Describe("Clan API Handler", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(count).To(BeEquivalentTo(1))
 
-					_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+					_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 					Expect(err).NotTo(HaveOccurred())
 
 					gameID := clan.GameID
@@ -1257,7 +1259,7 @@ var _ = Describe("Clan API Handler", func() {
 						"autoJoin":         clan.AutoJoin,
 					}
 					route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
-					status, body := PutJSON(a, route, payload)
+					status, body := PutJSON(app, route, payload)
 
 					Expect(status).To(Equal(http.StatusOK))
 					var result map[string]interface{}
@@ -1284,7 +1286,7 @@ var _ = Describe("Clan API Handler", func() {
 				})
 
 				It("Should call update clan hook if field in whitelist is new", func() {
-					hooks, err := models.GetHooksForRoutes(testDb, []string{
+					hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/clanupdatedhookwhitelist3",
 					}, models.ClanUpdatedHook)
 					Expect(err).NotTo(HaveOccurred())
@@ -1299,7 +1301,7 @@ var _ = Describe("Clan API Handler", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(count).To(BeEquivalentTo(1))
 
-					_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+					_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 					Expect(err).NotTo(HaveOccurred())
 
 					gameID := clan.GameID
@@ -1315,7 +1317,7 @@ var _ = Describe("Clan API Handler", func() {
 						"autoJoin":         clan.AutoJoin,
 					}
 					route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
-					status, body := PutJSON(a, route, payload)
+					status, body := PutJSON(app, route, payload)
 
 					Expect(status).To(Equal(http.StatusOK))
 					var result map[string]interface{}
@@ -1342,7 +1344,7 @@ var _ = Describe("Clan API Handler", func() {
 				})
 
 				It("Should not call update clan hook if field not in whitelist", func() {
-					hooks, err := models.GetHooksForRoutes(testDb, []string{
+					hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/clanupdatedhookwhitelist2",
 					}, models.ClanUpdatedHook)
 					Expect(err).NotTo(HaveOccurred())
@@ -1357,7 +1359,7 @@ var _ = Describe("Clan API Handler", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(count).To(BeEquivalentTo(1))
 
-					_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+					_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 					Expect(err).NotTo(HaveOccurred())
 
 					gameID := clan.GameID
@@ -1373,7 +1375,7 @@ var _ = Describe("Clan API Handler", func() {
 						"autoJoin":         clan.AutoJoin,
 					}
 					route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
-					status, body := PutJSON(a, route, payload)
+					status, body := PutJSON(app, route, payload)
 
 					Expect(status).To(Equal(http.StatusOK))
 					var result map[string]interface{}
@@ -1387,7 +1389,7 @@ var _ = Describe("Clan API Handler", func() {
 
 				Describe("Should call update clan hook if clan details changed", func() {
 					It("by name", func() {
-						hooks, err := models.GetHooksForRoutes(testDb, []string{
+						hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 							"http://localhost:52525/clanupdatedhookwhitelist4",
 						}, models.ClanUpdatedHook)
 						Expect(err).NotTo(HaveOccurred())
@@ -1402,7 +1404,7 @@ var _ = Describe("Clan API Handler", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(count).To(BeEquivalentTo(1))
 
-						_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+						_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 						Expect(err).NotTo(HaveOccurred())
 
 						gameID := clan.GameID
@@ -1418,7 +1420,7 @@ var _ = Describe("Clan API Handler", func() {
 							"autoJoin":         clan.AutoJoin,
 						}
 						route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
-						status, body := PutJSON(a, route, payload)
+						status, body := PutJSON(app, route, payload)
 
 						Expect(status).To(Equal(http.StatusOK))
 						var result map[string]interface{}
@@ -1431,7 +1433,7 @@ var _ = Describe("Clan API Handler", func() {
 					})
 
 					It("by AutoJoin", func() {
-						hooks, err := models.GetHooksForRoutes(testDb, []string{
+						hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 							"http://localhost:52525/clanupdatedhookwhitelist6",
 						}, models.ClanUpdatedHook)
 						Expect(err).NotTo(HaveOccurred())
@@ -1446,7 +1448,7 @@ var _ = Describe("Clan API Handler", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(count).To(BeEquivalentTo(1))
 
-						_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+						_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 						Expect(err).NotTo(HaveOccurred())
 
 						gameID := clan.GameID
@@ -1462,7 +1464,7 @@ var _ = Describe("Clan API Handler", func() {
 							"autoJoin":         !clan.AutoJoin,
 						}
 						route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
-						status, body := PutJSON(a, route, payload)
+						status, body := PutJSON(app, route, payload)
 
 						Expect(status).To(Equal(http.StatusOK))
 						var result map[string]interface{}
@@ -1475,7 +1477,7 @@ var _ = Describe("Clan API Handler", func() {
 					})
 
 					It("by AllowApplication", func() {
-						hooks, err := models.GetHooksForRoutes(testDb, []string{
+						hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 							"http://localhost:52525/clanupdatedhookwhitelist5",
 						}, models.ClanUpdatedHook)
 						Expect(err).NotTo(HaveOccurred())
@@ -1490,7 +1492,7 @@ var _ = Describe("Clan API Handler", func() {
 						Expect(err).NotTo(HaveOccurred())
 						Expect(count).To(BeEquivalentTo(1))
 
-						_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+						_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 						Expect(err).NotTo(HaveOccurred())
 
 						gameID := clan.GameID
@@ -1506,7 +1508,7 @@ var _ = Describe("Clan API Handler", func() {
 							"autoJoin":         clan.AutoJoin,
 						}
 						route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s", publicID))
-						status, body := PutJSON(a, route, payload)
+						status, body := PutJSON(app, route, payload)
 
 						Expect(status).To(Equal(http.StatusOK))
 						var result map[string]interface{}
@@ -1522,13 +1524,13 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should call leave clan hook", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/clanleave",
 			}, models.ClanLeftHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/clanleave"}, 52525)
 
-			_, clan, _, players, _, err := models.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -1536,7 +1538,7 @@ var _ = Describe("Clan API Handler", func() {
 
 			payload := map[string]interface{}{}
 			route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s/leave", publicID))
-			status, body := PostJSON(a, route, payload)
+			status, body := PostJSON(app, route, payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -1571,13 +1573,13 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should call leave clan hook when last member", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/clanleave2",
 			}, models.ClanLeftHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/clanleave2"}, 52525)
 
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -1585,7 +1587,7 @@ var _ = Describe("Clan API Handler", func() {
 
 			payload := map[string]interface{}{}
 			route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s/leave", publicID))
-			status, body := PostJSON(a, route, payload)
+			status, body := PostJSON(app, route, payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}
@@ -1616,13 +1618,13 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should call transfer ownership hook", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/clantransfer",
 			}, models.ClanOwnershipTransferredHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/clantransfer"}, 52525)
 
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -1632,7 +1634,7 @@ var _ = Describe("Clan API Handler", func() {
 				"playerPublicID": players[0].PublicID,
 			}
 			route := GetGameRoute(gameID, fmt.Sprintf("/clans/%s/transfer-ownership", publicID))
-			status, body := PostJSON(a, route, payload)
+			status, body := PostJSON(app, route, payload)
 
 			Expect(status).To(Equal(http.StatusOK))
 			var result map[string]interface{}

--- a/api/clan_test.go
+++ b/api/clan_test.go
@@ -1052,9 +1052,6 @@ var _ = Describe("Clan API Handler", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			// TODO: Replace this with something more reliable
-			// time.Sleep(10 * time.Second)
-
 			err = testing.CreateClanNameTextIndexInMongo(GetTestMongo, gameID)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/api/game_test.go
+++ b/api/game_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Game API Handler", func() {
 
 		a = GetDefaultTestApp()
 		db = a.Db(nil)
-		a.NonblockingStartWorkers()
+		fixtures.ConfigureAndStartGoWorkers()
 	})
 
 	Describe("Create Game Handler", func() {

--- a/api/game_test.go
+++ b/api/game_test.go
@@ -19,6 +19,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/api"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 )
 
 func getGamePayload(publicID, name string) map[string]interface{} {
@@ -169,7 +170,7 @@ var _ = Describe("Game API Handler", func() {
 
 	Describe("Update Game Handler", func() {
 		It("Should update game", func() {
-			game := models.GameFactory.MustCreate().(*models.Game)
+			game := fixtures.GameFactory.MustCreate().(*models.Game)
 			err := db.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -227,7 +228,7 @@ var _ = Describe("Game API Handler", func() {
 		})
 
 		It("Should not update game if missing parameters", func() {
-			game := models.GameFactory.MustCreate().(*models.Game)
+			game := fixtures.GameFactory.MustCreate().(*models.Game)
 			err := db.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -248,7 +249,7 @@ var _ = Describe("Game API Handler", func() {
 		})
 
 		It("Should not update game if bad payload", func() {
-			game := models.GameFactory.MustCreate().(*models.Game)
+			game := fixtures.GameFactory.MustCreate().(*models.Game)
 			err := db.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -276,7 +277,7 @@ var _ = Describe("Game API Handler", func() {
 		})
 
 		It("Should not update game if invalid data", func() {
-			game := models.GameFactory.MustCreate().(*models.Game)
+			game := fixtures.GameFactory.MustCreate().(*models.Game)
 			err := db.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -296,7 +297,7 @@ var _ = Describe("Game API Handler", func() {
 	Describe("Game Hooks", func() {
 		Describe("Update Game Hook", func() {
 			It("Should call update game hook", func() {
-				hooks, err := models.GetHooksForRoutes(testDb, []string{
+				hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 					"http://localhost:52525/update",
 				}, models.GameUpdatedHook)
 				Expect(err).NotTo(HaveOccurred())

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/topfreegames/khan/models"
-	testing "github.com/topfreegames/khan/models/fixtures"
+	"github.com/topfreegames/khan/models/fixtures"
 )
 
 var _ = Describe("Hook API Handler", func() {
@@ -31,7 +31,7 @@ var _ = Describe("Hook API Handler", func() {
 		It("Should create hook", func() {
 			a := GetDefaultTestApp()
 			db := a.Db(nil)
-			game := testing.GameFactory.MustCreate().(*models.Game)
+			game := fixtures.GameFactory.MustCreate().(*models.Game)
 			err := db.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -86,7 +86,7 @@ var _ = Describe("Hook API Handler", func() {
 		It("Should delete hook", func() {
 			a := GetDefaultTestApp()
 
-			hook, err := testing.CreateHookFactory(testDb, "", models.GameUpdatedHook, "http://test/update")
+			hook, err := fixtures.CreateHookFactory(testDb, "", models.GameUpdatedHook, "http://test/update")
 			Expect(err).NotTo(HaveOccurred())
 
 			status, body := Delete(a, GetGameRoute(hook.GameID, fmt.Sprintf("/hooks/%s", hook.PublicID)))

--- a/api/hook_test.go
+++ b/api/hook_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/topfreegames/khan/models"
+	testing "github.com/topfreegames/khan/models/fixtures"
 )
 
 var _ = Describe("Hook API Handler", func() {
@@ -30,7 +31,7 @@ var _ = Describe("Hook API Handler", func() {
 		It("Should create hook", func() {
 			a := GetDefaultTestApp()
 			db := a.Db(nil)
-			game := models.GameFactory.MustCreate().(*models.Game)
+			game := testing.GameFactory.MustCreate().(*models.Game)
 			err := db.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -85,7 +86,7 @@ var _ = Describe("Hook API Handler", func() {
 		It("Should delete hook", func() {
 			a := GetDefaultTestApp()
 
-			hook, err := models.CreateHookFactory(testDb, "", models.GameUpdatedHook, "http://test/update")
+			hook, err := testing.CreateHookFactory(testDb, "", models.GameUpdatedHook, "http://test/update")
 			Expect(err).NotTo(HaveOccurred())
 
 			status, body := Delete(a, GetGameRoute(hook.GameID, fmt.Sprintf("/hooks/%s", hook.PublicID)))

--- a/api/membership_test.go
+++ b/api/membership_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/topfreegames/khan/api"
 	"github.com/topfreegames/khan/models"
+	testing "github.com/topfreegames/khan/models/fixtures"
 )
 
 var _ = Describe("Membership API Handler", func() {
@@ -35,7 +36,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Apply For Membership Handler", func() {
 		It("Should create membership application", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AutoJoin = true
@@ -43,7 +44,7 @@ var _ = Describe("Membership API Handler", func() {
 			_, err = testDb.Update(clan)
 			Expect(err).NotTo(HaveOccurred())
 
-			player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -76,7 +77,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should create membership application sending a message", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AutoJoin = false
@@ -84,7 +85,7 @@ var _ = Describe("Membership API Handler", func() {
 			_, err = testDb.Update(clan)
 			Expect(err).NotTo(HaveOccurred())
 
-			player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -119,7 +120,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should conflict when player is already a member", func() {
-			_, clan, owner, players, memberships, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].RequestorID = memberships[0].PlayerID
@@ -155,7 +156,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should create membership application sending a message after player left clan", func() {
-			_, clan, _, players, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -205,7 +206,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should delete member", func() {
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -252,7 +253,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not create membership application if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -274,10 +275,10 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should not create membership application if invalid data", func() {
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -303,10 +304,10 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Invite For Membership Handler", func() {
 		It("Should create membership invitation if clan owner", func() {
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -339,10 +340,10 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should create membership invitation sending a message", func() {
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -377,7 +378,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should create membership invitation if requestor has level greater than min level", func() {
-			_, clan, _, players, memberships, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].Level = "CoLeader"
@@ -385,7 +386,7 @@ var _ = Describe("Membership API Handler", func() {
 			_, err = testDb.Update(memberships[0])
 			Expect(err).NotTo(HaveOccurred())
 
-			player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -443,7 +444,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not create membership invitation if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -466,10 +467,10 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should not create membership invitation if invalid data", func() {
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -496,7 +497,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Approve Or Deny Membership Invitation Handler", func() {
 		It("Should approve membership invitation", func() {
-			_, clan, _, players, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -521,7 +522,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should deny membership invitation", func() {
-			_, clan, _, players, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -570,7 +571,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not approve membership invitation if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -592,7 +593,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Approve Or Deny Membership Application Handler", func() {
 		It("Should approve membership application", func() {
-			_, clan, owner, players, memberships, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].RequestorID = memberships[0].PlayerID
@@ -619,7 +620,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should conflict when player is already a member", func() {
-			_, clan, owner, players, memberships, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].RequestorID = memberships[0].PlayerID
@@ -649,7 +650,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should deny membership application", func() {
-			_, clan, owner, players, memberships, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].RequestorID = memberships[0].PlayerID
@@ -700,7 +701,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not approve membership application if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -723,7 +724,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Promote Or Demote Member Handler", func() {
 		It("Should promote member", func() {
-			_, clan, owner, players, memberships, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].Approved = true
@@ -750,7 +751,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should demote member", func() {
-			_, clan, owner, players, memberships, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].Approved = true
@@ -802,7 +803,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not promote member if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -825,7 +826,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Delete Member Handler", func() {
 		It("Should delete member", func() {
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -872,7 +873,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not delete member if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -895,20 +896,20 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Membership Hooks", func() {
 		It("Apply should call membership application created hook with non empty message", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := testing.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipapply",
 			}, models.MembershipApplicationCreatedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipapply"}, 52525)
 
-			_, clan, _, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
 			_, err = testDb.Update(clan)
 			Expect(err).NotTo(HaveOccurred())
 
-			player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -940,20 +941,20 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Invite should call membership application created hook", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := testing.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipinvite",
 			}, models.MembershipApplicationCreatedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipinvite"}, 52525)
 
-			_, clan, owner, _, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
 			_, err = testDb.Update(clan)
 			Expect(err).NotTo(HaveOccurred())
 
-			player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -986,13 +987,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership approved hook on application", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := testing.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipapplicationapproved",
 			}, models.MembershipApprovedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipapplicationapproved"}, 52525)
 
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true, false)
+			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1025,13 +1026,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership approved hook on invitation", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := testing.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipinvitationapproved",
 			}, models.MembershipApprovedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipinvitationapproved"}, 52525)
 
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true)
+			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1064,13 +1065,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership denied hook on application", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := testing.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipapplicationdenied",
 			}, models.MembershipDeniedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipapplicationdenied"}, 52525)
 
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true, false)
+			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1103,13 +1104,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership denied hook on invitation", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := testing.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipinvitationdenied",
 			}, models.MembershipDeniedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipinvitationdenied"}, 52525)
 
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true)
+			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1142,13 +1143,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership promoted hook", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := testing.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershippromoted",
 			}, models.MembershipPromotedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershippromoted"}, 52525)
 
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1178,13 +1179,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership demoted hook", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := testing.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipdemoted",
 			}, models.MembershipDemotedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipdemoted"}, 52525)
 
-			_, clan, owner, players, memberships, err := models.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1218,13 +1219,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership deleted hook", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := testing.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipdeleted",
 			}, models.MembershipLeftHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipdeleted"}, 52525)
 
-			_, clan, owner, players, _, err := models.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true

--- a/api/membership_test.go
+++ b/api/membership_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/topfreegames/khan/api"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	testing "github.com/topfreegames/khan/models/fixtures"
 )
 
@@ -31,7 +32,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		a = GetDefaultTestApp()
 		db = a.Db(nil)
-		a.NonblockingStartWorkers()
+		fixtures.ConfigureAndStartGoWorkers()
 	})
 
 	Describe("Apply For Membership Handler", func() {

--- a/api/membership_test.go
+++ b/api/membership_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/topfreegames/khan/api"
 	"github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/models/fixtures"
-	testing "github.com/topfreegames/khan/models/fixtures"
 )
 
 var _ = Describe("Membership API Handler", func() {
@@ -37,7 +36,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Apply For Membership Handler", func() {
 		It("Should create membership application", func() {
-			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AutoJoin = true
@@ -45,7 +44,7 @@ var _ = Describe("Membership API Handler", func() {
 			_, err = testDb.Update(clan)
 			Expect(err).NotTo(HaveOccurred())
 
-			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -78,7 +77,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should create membership application sending a message", func() {
-			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AutoJoin = false
@@ -86,7 +85,7 @@ var _ = Describe("Membership API Handler", func() {
 			_, err = testDb.Update(clan)
 			Expect(err).NotTo(HaveOccurred())
 
-			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -121,7 +120,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should conflict when player is already a member", func() {
-			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].RequestorID = memberships[0].PlayerID
@@ -157,7 +156,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should create membership application sending a message after player left clan", func() {
-			_, clan, _, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -207,7 +206,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should delete member", func() {
-			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -254,7 +253,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not create membership application if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -276,10 +275,10 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should not create membership application if invalid data", func() {
-			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -305,10 +304,10 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Invite For Membership Handler", func() {
 		It("Should create membership invitation if clan owner", func() {
-			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -341,10 +340,10 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should create membership invitation sending a message", func() {
-			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -379,7 +378,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should create membership invitation if requestor has level greater than min level", func() {
-			_, clan, _, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].Level = "CoLeader"
@@ -387,7 +386,7 @@ var _ = Describe("Membership API Handler", func() {
 			_, err = testDb.Update(memberships[0])
 			Expect(err).NotTo(HaveOccurred())
 
-			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -445,7 +444,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not create membership invitation if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -468,10 +467,10 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should not create membership invitation if invalid data", func() {
-			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -498,7 +497,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Approve Or Deny Membership Invitation Handler", func() {
 		It("Should approve membership invitation", func() {
-			_, clan, _, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -523,7 +522,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should deny membership invitation", func() {
-			_, clan, _, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -572,7 +571,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not approve membership invitation if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -594,7 +593,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Approve Or Deny Membership Application Handler", func() {
 		It("Should approve membership application", func() {
-			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].RequestorID = memberships[0].PlayerID
@@ -621,7 +620,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should conflict when player is already a member", func() {
-			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].RequestorID = memberships[0].PlayerID
@@ -651,7 +650,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should deny membership application", func() {
-			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].RequestorID = memberships[0].PlayerID
@@ -702,7 +701,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not approve membership application if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -725,7 +724,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Promote Or Demote Member Handler", func() {
 		It("Should promote member", func() {
-			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].Approved = true
@@ -752,7 +751,7 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Should demote member", func() {
-			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].Approved = true
@@ -804,7 +803,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not promote member if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -827,7 +826,7 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Delete Member Handler", func() {
 		It("Should delete member", func() {
-			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := clan.GameID
@@ -874,7 +873,7 @@ var _ = Describe("Membership API Handler", func() {
 
 		It("Should not delete member if player does not exist", func() {
 			playerPublicID := randomdata.FullName(randomdata.RandomGender)
-			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			gameID := owner.GameID
@@ -897,20 +896,20 @@ var _ = Describe("Membership API Handler", func() {
 
 	Describe("Membership Hooks", func() {
 		It("Apply should call membership application created hook with non empty message", func() {
-			hooks, err := testing.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipapply",
 			}, models.MembershipApplicationCreatedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipapply"}, 52525)
 
-			_, clan, _, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
 			_, err = testDb.Update(clan)
 			Expect(err).NotTo(HaveOccurred())
 
-			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -942,20 +941,20 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("Invite should call membership application created hook", func() {
-			hooks, err := testing.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipinvite",
 			}, models.MembershipApplicationCreatedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipinvite"}, 52525)
 
-			_, clan, owner, _, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
 			_, err = testDb.Update(clan)
 			Expect(err).NotTo(HaveOccurred())
 
-			player := testing.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+			player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID": clan.GameID,
 			}).(*models.Player)
 			err = testDb.Insert(player)
@@ -988,13 +987,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership approved hook on application", func() {
-			hooks, err := testing.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipapplicationapproved",
 			}, models.MembershipApprovedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipapplicationapproved"}, 52525)
 
-			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true, false)
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1027,13 +1026,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership approved hook on invitation", func() {
-			hooks, err := testing.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipinvitationapproved",
 			}, models.MembershipApprovedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipinvitationapproved"}, 52525)
 
-			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true)
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1066,13 +1065,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership denied hook on application", func() {
-			hooks, err := testing.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipapplicationdenied",
 			}, models.MembershipDeniedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipapplicationdenied"}, 52525)
 
-			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true, false)
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1105,13 +1104,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership denied hook on invitation", func() {
-			hooks, err := testing.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipinvitationdenied",
 			}, models.MembershipDeniedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipinvitationdenied"}, 52525)
 
-			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true)
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1144,13 +1143,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership promoted hook", func() {
-			hooks, err := testing.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershippromoted",
 			}, models.MembershipPromotedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershippromoted"}, 52525)
 
-			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1180,13 +1179,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership demoted hook", func() {
-			hooks, err := testing.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipdemoted",
 			}, models.MembershipDemotedHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipdemoted"}, 52525)
 
-			_, clan, owner, players, memberships, err := testing.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true
@@ -1220,13 +1219,13 @@ var _ = Describe("Membership API Handler", func() {
 		})
 
 		It("should call membership deleted hook", func() {
-			hooks, err := testing.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/membershipdeleted",
 			}, models.MembershipLeftHook)
 			Expect(err).NotTo(HaveOccurred())
 			responses := startRouteHandler([]string{"/membershipdeleted"}, 52525)
 
-			_, clan, owner, players, _, err := testing.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
+			_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, hooks[0].GameID, "", true)
 			Expect(err).NotTo(HaveOccurred())
 
 			clan.AllowApplication = true

--- a/api/player_test.go
+++ b/api/player_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Player API Handler", func() {
 
 		a = GetDefaultTestApp()
 		db = a.Db(nil)
-		a.NonblockingStartWorkers()
+		fixtures.ConfigureAndStartGoWorkers()
 	})
 
 	Describe("Create Player Handler", func() {

--- a/api/player_test.go
+++ b/api/player_test.go
@@ -20,6 +20,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/api"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	"github.com/topfreegames/khan/testing"
 )
 
@@ -39,7 +40,7 @@ var _ = Describe("Player API Handler", func() {
 
 	Describe("Create Player Handler", func() {
 		It("Should create player", func() {
-			game := models.GameFactory.MustCreate().(*models.Game)
+			game := fixtures.GameFactory.MustCreate().(*models.Game)
 			err := db.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -89,7 +90,7 @@ var _ = Describe("Player API Handler", func() {
 		})
 
 		It("Should not create player if invalid data", func() {
-			game := models.GameFactory.MustCreate().(*models.Game)
+			game := fixtures.GameFactory.MustCreate().(*models.Game)
 			err := db.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -110,7 +111,7 @@ var _ = Describe("Player API Handler", func() {
 
 	Describe("Update Player Handler", func() {
 		It("Should update player", func() {
-			_, player, err := models.CreatePlayerFactory(db, "")
+			_, player, err := fixtures.CreatePlayerFactory(db, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			metadata := map[string]interface{}{"y": 10}
@@ -157,7 +158,7 @@ var _ = Describe("Player API Handler", func() {
 		})
 
 		It("Should not update player if invalid data", func() {
-			_, player, err := models.CreatePlayerFactory(db, "")
+			_, player, err := fixtures.CreatePlayerFactory(db, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			payload := map[string]interface{}{
@@ -179,7 +180,7 @@ var _ = Describe("Player API Handler", func() {
 	Describe("Retrieve Player", func() {
 		It("Should retrieve player", func() {
 			gameID := uuid.NewV4().String()
-			_, player, err := models.GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
+			_, player, err := fixtures.GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
 			Expect(err).NotTo(HaveOccurred())
 
 			route := GetGameRoute(player.GameID, fmt.Sprintf("/players/%s", player.PublicID))
@@ -217,7 +218,7 @@ var _ = Describe("Player API Handler", func() {
 
 		It("Should retrieve player decrypting player.Name", func() {
 			gameID := uuid.NewV4().String()
-			owner, player, err := models.GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
+			owner, player, err := fixtures.GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
 			Expect(err).NotTo(HaveOccurred())
 
 			testing.UpdateEncryptingTestPlayer(testDb, a.EncryptionKey, owner)
@@ -273,7 +274,7 @@ var _ = Describe("Player API Handler", func() {
 
 	Describe("Player Hooks", func() {
 		It("Should call create player hook", func() {
-			hooks, err := models.GetHooksForRoutes(testDb, []string{
+			hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 				"http://localhost:52525/playercreated",
 			}, models.PlayerCreatedHook)
 			Expect(err).NotTo(HaveOccurred())
@@ -313,13 +314,13 @@ var _ = Describe("Player API Handler", func() {
 		Describe("Update Player Hook", func() {
 			Describe("Without Whitelist", func() {
 				It("Should not call update player hook", func() {
-					hooks, err := models.GetHooksForRoutes(testDb, []string{
+					hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/updated",
 					}, models.PlayerUpdatedHook)
 					Expect(err).NotTo(HaveOccurred())
 					responses := startRouteHandler([]string{"/updated"}, 52525)
 
-					player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{"GameID": hooks[0].GameID}).(*models.Player)
+					player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{"GameID": hooks[0].GameID}).(*models.Player)
 					err = testDb.Insert(player)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -343,7 +344,7 @@ var _ = Describe("Player API Handler", func() {
 			})
 			Describe("With Whitelist", func() {
 				It("Should call update player hook if whitelisted", func() {
-					hooks, err := models.GetHooksForRoutes(testDb, []string{
+					hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/updated_whitelist",
 					}, models.PlayerUpdatedHook)
 					Expect(err).NotTo(HaveOccurred())
@@ -358,7 +359,7 @@ var _ = Describe("Player API Handler", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(count).To(BeEquivalentTo(1))
 
-					player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+					player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 						"GameID": hooks[0].GameID,
 						"Metadata": map[string]interface{}{
 							"new": "something",
@@ -400,7 +401,7 @@ var _ = Describe("Player API Handler", func() {
 				})
 
 				It("Should call update player hook if whitelisted and field is new", func() {
-					hooks, err := models.GetHooksForRoutes(testDb, []string{
+					hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/updated_whitelist_3",
 					}, models.PlayerUpdatedHook)
 					Expect(err).NotTo(HaveOccurred())
@@ -415,7 +416,7 @@ var _ = Describe("Player API Handler", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(count).To(BeEquivalentTo(1))
 
-					player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+					player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 						"GameID":   hooks[0].GameID,
 						"Metadata": map[string]interface{}{},
 					}).(*models.Player)
@@ -455,7 +456,7 @@ var _ = Describe("Player API Handler", func() {
 				})
 
 				It("Should not call update player hook if not whitelisted", func() {
-					hooks, err := models.GetHooksForRoutes(testDb, []string{
+					hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/updated_whitelist_2",
 					}, models.PlayerUpdatedHook)
 					Expect(err).NotTo(HaveOccurred())
@@ -470,7 +471,7 @@ var _ = Describe("Player API Handler", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(count).To(BeEquivalentTo(1))
 
-					player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+					player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 						"GameID": hooks[0].GameID,
 						"Metadata": map[string]interface{}{
 							"else": "something",
@@ -500,7 +501,7 @@ var _ = Describe("Player API Handler", func() {
 				})
 
 				It("Should call update player hook if whitelisted and player does not exist", func() {
-					hooks, err := models.GetHooksForRoutes(testDb, []string{
+					hooks, err := fixtures.GetHooksForRoutes(testDb, []string{
 						"http://localhost:52525/updated_whitelist_not_exist",
 					}, models.PlayerUpdatedHook)
 					Expect(err).NotTo(HaveOccurred())

--- a/bench/clan_test.go
+++ b/bench/clan_test.go
@@ -15,6 +15,7 @@ import (
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	khanTesting "github.com/topfreegames/khan/testing"
 )
 
@@ -33,7 +34,7 @@ func BenchmarkCreateClan(b *testing.B) {
 
 	var players []*models.Player
 	for i := 0; i < b.N; i++ {
-		player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+		player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 			"GameID": game.PublicID,
 		}).(*models.Player)
 		err = db.Insert(player)
@@ -91,7 +92,7 @@ func BenchmarkRetrieveClan(b *testing.B) {
 	}
 
 	gameID := uuid.NewV4().String()
-	_, clan, _, _, _, err := models.GetClanWithMemberships(
+	_, clan, _, _, _, err := fixtures.GetClanWithMemberships(
 		db, 50, 50, 50, 50, gameID, uuid.NewV4().String(),
 	)
 
@@ -118,7 +119,7 @@ func BenchmarkRetrieveClanSummary(b *testing.B) {
 	}
 
 	gameID := uuid.NewV4().String()
-	_, clan, _, _, _, err := models.GetClanWithMemberships(
+	_, clan, _, _, _, err := fixtures.GetClanWithMemberships(
 		db, 50, 50, 50, 50, gameID, uuid.NewV4().String(),
 	)
 
@@ -268,7 +269,7 @@ func BenchmarkTransferOwnership(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, clan, owner, members, _, err := models.GetClanWithMemberships(
+	game, clan, owner, members, _, err := fixtures.GetClanWithMemberships(
 		db, 20, 0, 0, 0, "", "",
 	)
 	if err != nil {

--- a/bench/game_test.go
+++ b/bench/game_test.go
@@ -13,8 +13,9 @@ import (
 	"testing"
 
 	"github.com/Pallinder/go-randomdata"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 )
 
 var gameResult *http.Response
@@ -67,7 +68,7 @@ func BenchmarkUpdateGame(b *testing.B) {
 
 	var games []*models.Game
 	for i := 0; i < b.N; i++ {
-		game := models.GameFactory.MustCreateWithOption(map[string]interface{}{
+		game := fixtures.GameFactory.MustCreateWithOption(map[string]interface{}{
 			"PublicID":          uuid.NewV4().String(),
 			"MaxClansPerPlayer": 999999,
 		}).(*models.Game)

--- a/bench/helpers.go
+++ b/bench/helpers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/topfreegames/extensions/v9/mongo"
 	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 )
 
 func getTestMongo() (interfaces.MongoDB, error) {
@@ -100,7 +101,7 @@ func getPlayerPayload(playerPublicID string) map[string]interface{} {
 }
 
 func getGameAndPlayer(db models.DB) (*models.Game, *models.Player, error) {
-	game := models.GameFactory.MustCreateWithOption(map[string]interface{}{
+	game := fixtures.GameFactory.MustCreateWithOption(map[string]interface{}{
 		"PublicID":          uuid.NewV4().String(),
 		"MaxClansPerPlayer": 999999,
 	}).(*models.Game)
@@ -108,7 +109,7 @@ func getGameAndPlayer(db models.DB) (*models.Game, *models.Player, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+	player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":   game.PublicID,
 		"PublicID": uuid.NewV4().String(),
 	}).(*models.Player)
@@ -134,7 +135,7 @@ func validateResp(res *http.Response, err error) {
 func createClans(db models.DB, game *models.Game, owner *models.Player, numberOfClans int) ([]*models.Clan, error) {
 	var clans []*models.Clan
 	for i := 0; i < numberOfClans; i++ {
-		clan := models.ClanFactory.MustCreateWithOption(map[string]interface{}{
+		clan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 			"GameID":   game.PublicID,
 			"PublicID": uuid.NewV4().String(),
 			"OwnerID":  owner.ID,

--- a/bench/membership_test.go
+++ b/bench/membership_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 )
 
 var membershipResult *http.Response
@@ -23,7 +24,7 @@ func BenchmarkApplyForMembership(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, clan, _, _, _, err := models.GetClanWithMemberships(db, 20, 20, 20, 20, "", "")
+	game, clan, _, _, _, err := fixtures.GetClanWithMemberships(db, 20, 20, 20, 20, "", "")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -41,7 +42,7 @@ func BenchmarkApplyForMembership(b *testing.B) {
 
 	var players []*models.Player
 	for i := 0; i < b.N; i++ {
-		player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+		player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 			"GameID": game.PublicID,
 		}).(*models.Player)
 		err = db.Insert(player)
@@ -73,7 +74,7 @@ func BenchmarkInviteForMembership(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, clan, owner, _, _, err := models.GetClanWithMemberships(db, 20, 20, 20, 20, "", "")
+	game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(db, 20, 20, 20, 20, "", "")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -85,7 +86,7 @@ func BenchmarkInviteForMembership(b *testing.B) {
 
 	var players []*models.Player
 	for i := 0; i < b.N; i++ {
-		player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+		player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 			"GameID": game.PublicID,
 		}).(*models.Player)
 		err = db.Insert(player)
@@ -118,7 +119,7 @@ func BenchmarkApproveMembershipApplication(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, clan, owner, players, memberships, err := models.GetClanWithMemberships(db, 0, 0, 0, b.N, "", "")
+	game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(db, 0, 0, 0, b.N, "", "")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -158,7 +159,7 @@ func BenchmarkApproveMembershipInvitation(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, clan, _, players, _, err := models.GetClanWithMemberships(db, 0, 0, 0, b.N, "", "")
+	game, clan, _, players, _, err := fixtures.GetClanWithMemberships(db, 0, 0, 0, b.N, "", "")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -190,7 +191,7 @@ func BenchmarkDeleteMembership(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, clan, owner, players, _, err := models.GetClanWithMemberships(db, b.N, 0, 0, 0, "", "")
+	game, clan, owner, players, _, err := fixtures.GetClanWithMemberships(db, b.N, 0, 0, 0, "", "")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -217,7 +218,7 @@ func BenchmarkPromoteMembership(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, clan, owner, players, _, err := models.GetClanWithMemberships(db, b.N, 0, 0, 0, "", "")
+	game, clan, owner, players, _, err := fixtures.GetClanWithMemberships(db, b.N, 0, 0, 0, "", "")
 	if err != nil {
 		panic(err.Error())
 	}
@@ -244,7 +245,7 @@ func BenchmarkDemoteMembership(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, clan, owner, players, memberships, err := models.GetClanWithMemberships(db, b.N, 0, 0, 0, "", "")
+	game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(db, b.N, 0, 0, 0, "", "")
 	if err != nil {
 		panic(err.Error())
 	}

--- a/bench/player_test.go
+++ b/bench/player_test.go
@@ -14,6 +14,7 @@ import (
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 )
 
 var playerResult *http.Response
@@ -54,7 +55,7 @@ func BenchmarkUpdatePlayer(b *testing.B) {
 
 	var players []*models.Player
 	for i := 0; i < b.N; i++ {
-		player := models.PlayerFactory.MustCreateWithOption(map[string]interface{}{
+		player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 			"GameID": game.PublicID,
 		}).(*models.Player)
 		err = db.Insert(player)
@@ -84,7 +85,7 @@ func BenchmarkRetrievePlayer(b *testing.B) {
 	}
 
 	gameID := uuid.NewV4().String()
-	_, player, err := models.GetTestPlayerWithMemberships(db, gameID, 50, 20, 30, 80)
+	_, player, err := fixtures.GetTestPlayerWithMemberships(db, gameID, 50, 20, 30, 80)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Clan Cache", func() {
 
 		It("Should return a cached payload for a second call made immediately after the first", func() {
 			gameID := uuid.NewV4().String()
-			_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, nil)
+			_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, fixtures.EnqueueClanForMongoUpdate)
 			Expect(err).NotTo(HaveOccurred())
 
 			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)
@@ -100,7 +100,7 @@ var _ = Describe("Clan Cache", func() {
 
 		It("Should return fresh information after expiration time is reached", func() {
 			gameID := uuid.NewV4().String()
-			_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, nil)
+			_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, fixtures.EnqueueClanForMongoUpdate)
 			Expect(err).NotTo(HaveOccurred())
 
 			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	"github.com/topfreegames/khan/testing"
 )
 
@@ -76,7 +77,7 @@ var _ = Describe("Clan Cache", func() {
 
 		It("Should return a cached payload for a second call made immediately after the first", func() {
 			gameID := uuid.NewV4().String()
-			_, clans, err := models.GetTestClans(testDb, gameID, "test-sort-clan", 10)
+			_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)
@@ -99,7 +100,7 @@ var _ = Describe("Clan Cache", func() {
 
 		It("Should return fresh information after expiration time is reached", func() {
 			gameID := uuid.NewV4().String()
-			_, clans, err := models.GetTestClans(testDb, gameID, "test-sort-clan", 10)
+			_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)

--- a/cmd/prune_test.go
+++ b/cmd/prune_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/viper"
 	. "github.com/topfreegames/khan/cmd"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 )
 
 var _ = Describe("Prune Command", func() {
@@ -57,7 +58,7 @@ var _ = Describe("Prune Command", func() {
 				invites := rand.Intn(10)
 				denies := rand.Intn(10)
 				deletes := rand.Intn(10)
-				_, err := models.GetTestClanWithStaleData(db, apps, invites, denies, deletes)
+				_, err := fixtures.GetTestClanWithStaleData(db, apps, invites, denies, deletes)
 				Expect(err).NotTo(HaveOccurred())
 				totalApps += apps
 				totalInvites += invites
@@ -88,7 +89,7 @@ var _ = Describe("Prune Command", func() {
 				invites := rand.Intn(10)
 				denies := rand.Intn(10)
 				deletes := rand.Intn(10)
-				gameID, err := models.GetTestClanWithStaleData(db, apps, invites, denies, deletes)
+				gameID, err := fixtures.GetTestClanWithStaleData(db, apps, invites, denies, deletes)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = db.Exec("UPDATE games SET metadata='{}' WHERE public_id=$1", gameID)

--- a/models/clan_test.go
+++ b/models/clan_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/api"
 	. "github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	"github.com/topfreegames/khan/testing"
 	"github.com/topfreegames/khan/util"
 
@@ -30,6 +31,7 @@ var _ = Describe("Clan Model", func() {
 	var testDb DB
 	var testMongo interfaces.MongoDB
 	var faultyDb DB
+	// var mongoWorker *MongoWorker
 
 	BeforeEach(func() {
 		var err error
@@ -39,7 +41,7 @@ var _ = Describe("Clan Model", func() {
 		testMongo, err = GetTestMongo()
 		Expect(err).NotTo(HaveOccurred())
 
-		ConfigureAndStartGoWorkers()
+		_, _ = ConfigureAndStartGoWorkers()
 
 		faultyDb = GetFaultyTestDB()
 	})
@@ -48,7 +50,7 @@ var _ = Describe("Clan Model", func() {
 		Describe("Basic Operations", func() {
 			It("Should sort clans by name", func() {
 				gameID := uuid.NewV4().String()
-				_, clans, err := GetTestClans(testDb, gameID, "test-sort-clan", 10)
+				_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				sort.Sort(ClanByName(clans))
@@ -59,7 +61,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should create a new Clan", func() {
-				_, clans, err := GetTestClans(testDb, "", "", 1)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 				Expect(clan.ID).NotTo(BeEquivalentTo(0))
@@ -72,7 +74,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should update a Clan", func() {
-				_, clans, err := GetTestClans(testDb, "", "", 1)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -89,7 +91,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Id", func() {
 			It("Should get existing Clan", func() {
-				_, clans, err := GetTestClans(testDb, "", "", 1)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -107,7 +109,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Public Id", func() {
 			It("Should get an existing Clan by Game and PublicID", func() {
-				_, clans, err := GetTestClans(testDb, "", "", 1)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -125,7 +127,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Public Id", func() {
 			It("Should get an existing Clan by Game and PublicID prefix", func() {
-				_, clans, err := GetTestClans(testDb, "", "", 1)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -144,13 +146,13 @@ var _ = Describe("Clan Model", func() {
 		Describe("Get By Public Ids", func() {
 			It("Should get existing Clans by Game and PublicIDs", func() {
 				gameID := uuid.NewV4().String()
-				_, clan1, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan1, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String())
 				Expect(err).NotTo(HaveOccurred())
-				_, clan2, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan2, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String(), true)
 				Expect(err).NotTo(HaveOccurred())
-				_, clan3, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan3, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String(), true)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -171,13 +173,13 @@ var _ = Describe("Clan Model", func() {
 
 			It("Should get only existing Clans by Game and PublicIDs, unexistent ID", func() {
 				gameID := uuid.NewV4().String()
-				_, clan1, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan1, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String())
 				Expect(err).NotTo(HaveOccurred())
-				_, clan2, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan2, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String(), true)
 				Expect(err).NotTo(HaveOccurred())
-				_, clan3, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan3, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String(), true)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -194,7 +196,7 @@ var _ = Describe("Clan Model", func() {
 
 			It("Should get only existing Clans by Game and PublicIDs, unexistent Game", func() {
 				gameID := uuid.NewV4().String()
-				_, clan1, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan1, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String())
 				Expect(err).NotTo(HaveOccurred())
 
@@ -212,7 +214,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Public Id and OwnerPublicID", func() {
 			It("Should get an existing Clan by Game, PublicID and OwnerPublicID", func() {
-				player, clans, err := GetTestClans(testDb, "", "", 1)
+				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -232,7 +234,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not get a existing Clan by Game, PublicID and OwnerPublicID if not Clan owner", func() {
-				_, clans, err := GetTestClans(testDb, "", "", 1)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -244,13 +246,13 @@ var _ = Describe("Clan Model", func() {
 			Describe("Update Clan Membership Count", func() {
 				It("Should work if membership is created", func() {
 					previousAmount := 5
-					_, clan, _, _, _, err := GetClanWithMemberships(testDb, previousAmount-1, 2, 3, 4, "", "")
+					_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, previousAmount-1, 2, 3, 4, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
-					_, player, err := CreatePlayerFactory(testDb, clan.GameID, true)
+					_, player, err := fixtures.CreatePlayerFactory(testDb, clan.GameID, true)
 					Expect(err).NotTo(HaveOccurred())
 
-					membership := MembershipFactory.MustCreateWithOption(map[string]interface{}{
+					membership := fixtures.MembershipFactory.MustCreateWithOption(map[string]interface{}{
 						"GameID":      player.GameID,
 						"PlayerID":    player.ID,
 						"ClanID":      clan.ID,
@@ -270,7 +272,7 @@ var _ = Describe("Clan Model", func() {
 
 				It("Should work if membership is deleted", func() {
 					previousAmount := 5
-					_, clan, _, _, memberships, err := GetClanWithMemberships(testDb, previousAmount-1, 2, 3, 4, "", "")
+					_, clan, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, previousAmount-1, 2, 3, 4, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err = testDb.Delete(memberships[0])
@@ -293,12 +295,12 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Create Clan", func() {
 			It("Should create a new Clan with CreateClan", func() {
-				game, player, err := CreatePlayerFactory(testDb, "")
+				game, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				clan, err := CreateClan(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					player.GameID,
 					"create-1",
 					randomdata.FullName(randomdata.RandomGender),
@@ -319,18 +321,18 @@ var _ = Describe("Clan Model", func() {
 				Expect(dbClan.PublicID).To(Equal(clan.PublicID))
 				Expect(dbClan.MembershipCount).To(Equal(1))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.OwnershipCount).To(Equal(1))
 			})
 
 			It("Should not create a new Clan with CreateClan if invalid data", func() {
-				game, player, err := CreatePlayerFactory(testDb, "")
+				game, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateClan(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					player.GameID,
 					strings.Repeat("a", 256),
 					"clan-name",
@@ -346,12 +348,12 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not create a new Clan with CreateClan if reached MaxClansPerPlayer - owner", func() {
-				game, _, owner, _, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, _, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateClan(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					owner.GameID,
 					"create-1",
 					randomdata.FullName(randomdata.RandomGender),
@@ -367,12 +369,12 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not create a new Clan with CreateClan if reached MaxClansPerPlayer - member", func() {
-				game, _, _, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, _, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateClan(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game.PublicID,
 					"create-1",
 					randomdata.FullName(randomdata.RandomGender),
@@ -388,11 +390,11 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not create a new Clan with CreateClan if unexistent player", func() {
-				game, _, err := CreatePlayerFactory(testDb, "")
+				game, _, err := fixtures.CreatePlayerFactory(testDb, "")
 				playerPublicID := randomdata.FullName(randomdata.RandomGender)
 				_, err = CreateClan(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					"create-1",
 					randomdata.FullName(randomdata.RandomGender),
 					"clan-name",
@@ -410,7 +412,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Update Clan", func() {
 			It("Should update a Clan with UpdateClan", func() {
-				player, clans, err := GetTestClans(testDb, "", "", 1)
+				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -441,11 +443,11 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not update a Clan if player is not the clan owner with UpdateClan", func() {
-				_, clans, err := GetTestClans(testDb, "", "", 1)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
-				_, player, err := CreatePlayerFactory(testDb, clan.GameID, true)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, clan.GameID, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				metadata := map[string]interface{}{"x": "1"}
@@ -470,7 +472,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not update a Clan with Invalid Data with UpdateClan", func() {
-				player, clans, err := GetTestClans(testDb, "", "", 1)
+				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -491,7 +493,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			Measure("Should update a Clan with UpdateClan", func(b Benchmarker) {
-				player, clans, err := GetTestClans(testDb, "", "", 1)
+				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -519,10 +521,10 @@ var _ = Describe("Clan Model", func() {
 		Describe("Leave Clan", func() {
 			Describe("Should leave a Clan with LeaveClan if clan owner", func() {
 				It("And clan has memberships", func() {
-					_, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+					_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
-					clan, previousOwner, newOwner, err := LeaveClan(testDb, GetEncryptionKey(), clan.GameID, clan.PublicID)
+					clan, previousOwner, newOwner, err := LeaveClan(testDb, fixtures.GetEncryptionKey(), clan.GameID, clan.PublicID)
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(previousOwner.ID).To(Equal(owner.ID))
@@ -536,11 +538,11 @@ var _ = Describe("Clan Model", func() {
 					Expect(dbDeletedMembership.DeletedBy).To(Equal(memberships[0].PlayerID))
 					Expect(dbDeletedMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-					dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), owner.ID)
+					dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), owner.ID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 
-					dbPlayer, err = GetPlayerByID(testDb, GetEncryptionKey(), memberships[0].PlayerID)
+					dbPlayer, err = GetPlayerByID(testDb, fixtures.GetEncryptionKey(), memberships[0].PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(1))
 					Expect(dbPlayer.MembershipCount).To(Equal(0))
@@ -551,10 +553,10 @@ var _ = Describe("Clan Model", func() {
 				})
 
 				It("And clan has no memberships", func() {
-					_, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+					_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
-					clan, previousOwner, newOwner, err := LeaveClan(testDb, GetEncryptionKey(), clan.GameID, clan.PublicID)
+					clan, previousOwner, newOwner, err := LeaveClan(testDb, fixtures.GetEncryptionKey(), clan.GameID, clan.PublicID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(previousOwner.ID).To(Equal(owner.ID))
 					Expect(newOwner).To(BeNil())
@@ -563,7 +565,7 @@ var _ = Describe("Clan Model", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal(fmt.Sprintf("Clan was not found with id: %s", clan.PublicID)))
 
-					dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), owner.ID)
+					dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), owner.ID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 				})
@@ -572,10 +574,10 @@ var _ = Describe("Clan Model", func() {
 
 			Describe("Should not leave a Clan with LeaveClan if", func() {
 				It("Clan does not exist", func() {
-					_, clan, _, _, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+					_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
-					_, _, _, err = LeaveClan(testDb, GetEncryptionKey(), clan.GameID, "-1")
+					_, _, _, err = LeaveClan(testDb, fixtures.GetEncryptionKey(), clan.GameID, "-1")
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("Clan was not found with id: -1"))
 				})
@@ -585,11 +587,11 @@ var _ = Describe("Clan Model", func() {
 		Describe("Transfer Clan Ownership", func() {
 			Describe("Should transfer the Clan ownership with TransferClanOwnership if clan owner", func() {
 				It("And first clan owner and next owner memberhip exists", func() {
-					game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+					game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 					clan, previousOwner, newOwner, err := TransferClanOwnership(
 						testDb,
-						GetEncryptionKey(),
+						fixtures.GetEncryptionKey(),
 						clan.GameID,
 						clan.PublicID,
 						players[0].PublicID,
@@ -616,24 +618,24 @@ var _ = Describe("Clan Model", func() {
 					Expect(newOwnerMembership.DeletedBy).To(Equal(newOwnerMembership.PlayerID))
 					Expect(newOwnerMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-					dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), owner.ID)
+					dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), owner.ID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 					Expect(dbPlayer.MembershipCount).To(Equal(1))
 
-					dbPlayer, err = GetPlayerByID(testDb, GetEncryptionKey(), newOwnerMembership.PlayerID)
+					dbPlayer, err = GetPlayerByID(testDb, fixtures.GetEncryptionKey(), newOwnerMembership.PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(1))
 					Expect(dbPlayer.MembershipCount).To(Equal(0))
 				})
 
 				It("And not first clan owner and next owner membership exists", func() {
-					game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 2, 0, 0, 0, "", "")
+					game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 2, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
 					clan, previousOwner, newOwner, err := TransferClanOwnership(
 						testDb,
-						GetEncryptionKey(),
+						fixtures.GetEncryptionKey(),
 						clan.GameID,
 						clan.PublicID,
 						players[0].PublicID,
@@ -646,7 +648,7 @@ var _ = Describe("Clan Model", func() {
 
 					clan, previousOwner, newOwner, err = TransferClanOwnership(
 						testDb,
-						GetEncryptionKey(),
+						fixtures.GetEncryptionKey(),
 						clan.GameID,
 						clan.PublicID,
 						players[1].PublicID,
@@ -677,17 +679,17 @@ var _ = Describe("Clan Model", func() {
 					Expect(newOwnerMembership.DeletedBy).To(Equal(newOwnerMembership.PlayerID))
 					Expect(newOwnerMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-					dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), firstOwnerMembership.PlayerID)
+					dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), firstOwnerMembership.PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 					Expect(dbPlayer.MembershipCount).To(Equal(1))
 
-					dbPlayer, err = GetPlayerByID(testDb, GetEncryptionKey(), previousOwnerMembership.PlayerID)
+					dbPlayer, err = GetPlayerByID(testDb, fixtures.GetEncryptionKey(), previousOwnerMembership.PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(0))
 					Expect(dbPlayer.MembershipCount).To(Equal(1))
 
-					dbPlayer, err = GetPlayerByID(testDb, GetEncryptionKey(), newOwnerMembership.PlayerID)
+					dbPlayer, err = GetPlayerByID(testDb, fixtures.GetEncryptionKey(), newOwnerMembership.PlayerID)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dbPlayer.OwnershipCount).To(Equal(1))
 					Expect(dbPlayer.MembershipCount).To(Equal(0))
@@ -696,12 +698,12 @@ var _ = Describe("Clan Model", func() {
 
 			Describe("Should not transfer the Clan ownership with TransferClanOwnership if", func() {
 				It("Clan does not exist", func() {
-					game, clan, _, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+					game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
 					_, _, _, err = TransferClanOwnership(
 						testDb,
-						GetEncryptionKey(),
+						fixtures.GetEncryptionKey(),
 						clan.GameID,
 						"-1",
 						players[0].PublicID,
@@ -713,12 +715,12 @@ var _ = Describe("Clan Model", func() {
 				})
 
 				It("Membership does not exist", func() {
-					game, clan, _, _, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+					game, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 					Expect(err).NotTo(HaveOccurred())
 
 					_, _, _, err = TransferClanOwnership(
 						testDb,
-						GetEncryptionKey(),
+						fixtures.GetEncryptionKey(),
 						clan.GameID,
 						clan.PublicID,
 						"some-random-player",
@@ -733,7 +735,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get List of Clans", func() {
 			It("Should get all clans", func() {
-				player, _, err := GetTestClans(testDb, "", "", 10)
+				player, _, err := fixtures.CreateTestClans(testDb, "", "", 10, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				clans, err := GetAllClans(testDb, player.GameID)
@@ -759,12 +761,12 @@ var _ = Describe("Clan Model", func() {
 		Describe("Get Clan Members", func() {
 			It("Should get clan player ids", func() {
 				gameID := uuid.NewV4().String()
-				_, clan, _, _, _, err := GetClanWithMemberships(
+				_, clan, _, _, _, err := fixtures.GetClanWithMemberships(
 					testDb, 10, 3, 4, 5, gameID, uuid.NewV4().String(),
 				)
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, fixtures.GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 
 				clanPlayers, err := GetClanMembers(testDb, clan.GameID, clan.PublicID)
@@ -780,12 +782,12 @@ var _ = Describe("Clan Model", func() {
 
 			It("Should return empty list if no memberships", func() {
 				gameID := uuid.NewV4().String()
-				_, clan, _, _, _, err := GetClanWithMemberships(
+				_, clan, _, _, _, err := fixtures.GetClanWithMemberships(
 					testDb, 0, 3, 4, 5, gameID, uuid.NewV4().String(),
 				)
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, fixtures.GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 
 				clanPlayers, err := GetClanMembers(testDb, clan.GameID, clan.PublicID)
@@ -799,14 +801,14 @@ var _ = Describe("Clan Model", func() {
 		Describe("Get Clan Details", func() {
 			It("Should get clan members", func() {
 				gameID := uuid.NewV4().String()
-				_, clan, owner, players, memberships, err := GetClanWithMemberships(
+				_, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(
 					testDb, 10, 3, 4, 5, gameID, uuid.NewV4().String(),
 				)
 				Expect(err).NotTo(HaveOccurred())
 
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, fixtures.GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clanData["name"]).To(Equal(clan.Name))
 				Expect(clanData["metadata"]).To(Equal(clan.Metadata))
@@ -900,7 +902,7 @@ var _ = Describe("Clan Model", func() {
 
 			It("Should not get deleted clan members", func() {
 				gameID := uuid.NewV4().String()
-				_, clan, _, players, memberships, err := GetClanWithMemberships(
+				_, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(
 					testDb, 10, 0, 0, 0, gameID, uuid.NewV4().String(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -912,7 +914,7 @@ var _ = Describe("Clan Model", func() {
 
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, fixtures.GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clanData["name"]).To(Equal(clan.Name))
 				Expect(clanData["metadata"]).To(Equal(clan.Metadata))
@@ -935,7 +937,7 @@ var _ = Describe("Clan Model", func() {
 
 			It("Should get clan details even if no members", func() {
 				gameID := uuid.NewV4().String()
-				_, clan, _, _, _, err := GetClanWithMemberships(
+				_, clan, _, _, _, err := fixtures.GetClanWithMemberships(
 					testDb, 0, 0, 0, 0, gameID, uuid.NewV4().String(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -946,7 +948,7 @@ var _ = Describe("Clan Model", func() {
 
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, fixtures.GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clanData["name"]).To(Equal(clan.Name))
 				Expect(clanData["metadata"]).To(Equal(clan.Metadata))
@@ -959,22 +961,22 @@ var _ = Describe("Clan Model", func() {
 
 			It("Should get clan members decrypting player name", func() {
 				gameID := uuid.NewV4().String()
-				_, clan, owner, players, _, err := GetClanWithMemberships(
+				_, clan, owner, players, _, err := fixtures.GetClanWithMemberships(
 					testDb, 10, 3, 4, 5, gameID, uuid.NewV4().String(),
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				testing.UpdateEncryptingTestPlayer(testDb, GetEncryptionKey(), owner)
+				testing.UpdateEncryptingTestPlayer(testDb, fixtures.GetEncryptionKey(), owner)
 				for _, player := range players {
-					testing.UpdateEncryptingTestPlayer(testDb, GetEncryptionKey(), player)
+					testing.UpdateEncryptingTestPlayer(testDb, fixtures.GetEncryptionKey(), player)
 				}
 
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, fixtures.GetEncryptionKey(), clan.GameID, clan, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(err).NotTo(HaveOccurred())
 
-				name, err := util.DecryptData(owner.Name, GetEncryptionKey())
+				name, err := util.DecryptData(owner.Name, fixtures.GetEncryptionKey())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clanData["owner"].(map[string]interface{})["name"]).To(Equal(name))
 
@@ -995,7 +997,7 @@ var _ = Describe("Clan Model", func() {
 
 				playerDict := map[string]*Player{}
 				for _, player := range players {
-					testing.DecryptTestPlayer(GetEncryptionKey(), player)
+					testing.DecryptTestPlayer(fixtures.GetEncryptionKey(), player)
 					playerDict[player.PublicID] = player
 				}
 
@@ -1046,7 +1048,7 @@ var _ = Describe("Clan Model", func() {
 			It("Should fail if clan does not exist", func() {
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), "fake-game-id", &Clan{PublicID: "fake-public-id"}, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, fixtures.GetEncryptionKey(), "fake-game-id", &Clan{PublicID: "fake-public-id"}, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(clanData).To(BeNil())
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Clan was not found with id: fake-public-id"))
@@ -1056,7 +1058,7 @@ var _ = Describe("Clan Model", func() {
 		Describe("Get Clan Summary", func() {
 			It("Should get clan members", func() {
 				gameID := uuid.NewV4().String()
-				_, clan, _, _, _, err := GetClanWithMemberships(
+				_, clan, _, _, _, err := fixtures.GetClanWithMemberships(
 					testDb, 10, 3, 4, 5, gameID, uuid.NewV4().String(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -1075,7 +1077,7 @@ var _ = Describe("Clan Model", func() {
 			It("Should fail if clan does not exist", func() {
 				config := viper.New()
 				api.SetRetrieveClanHandlerConfigurationDefaults(config)
-				clanData, err := GetClanDetails(testDb, GetEncryptionKey(), "fake-game-id", &Clan{PublicID: "fake-public-id"}, 1, NewDefaultGetClanDetailsOptions(config))
+				clanData, err := GetClanDetails(testDb, fixtures.GetEncryptionKey(), "fake-game-id", &Clan{PublicID: "fake-public-id"}, 1, NewDefaultGetClanDetailsOptions(config))
 				Expect(clanData).To(BeNil())
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Clan was not found with id: fake-public-id"))
@@ -1087,13 +1089,13 @@ var _ = Describe("Clan Model", func() {
 			It("Should get clan members", func() {
 				gameID := uuid.NewV4().String()
 
-				_, clan1, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan1, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String())
 				Expect(err).NotTo(HaveOccurred())
-				_, clan2, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan2, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String(), true)
 				Expect(err).NotTo(HaveOccurred())
-				_, clan3, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan3, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String(), true)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1123,13 +1125,13 @@ var _ = Describe("Clan Model", func() {
 			It("Should retrieve only existent clans", func() {
 				gameID := uuid.NewV4().String()
 
-				_, clan1, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan1, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String())
 				Expect(err).NotTo(HaveOccurred())
-				_, clan2, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan2, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String(), true)
 				Expect(err).NotTo(HaveOccurred())
-				_, clan3, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
+				_, clan3, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID,
 					uuid.NewV4().String(), true)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -1151,7 +1153,7 @@ var _ = Describe("Clan Model", func() {
 			It("Should fail if game does not exist", func() {
 				gameID := uuid.NewV4().String()
 				clanID := uuid.NewV4().String()
-				_, clan1, _, _, _, err1 := GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, clanID)
+				_, clan1, _, _, _, err1 := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, gameID, clanID)
 				Expect(err1).To(BeNil())
 
 				clanIDs := []string{clan1.PublicID}
@@ -1173,8 +1175,8 @@ var _ = Describe("Clan Model", func() {
 
 			BeforeEach(func() {
 				var err error
-				player, realClans, err = GetTestClans(
-					testDb, "", "clan-search-clan", 10,
+				player, realClans, err = fixtures.CreateTestClans(
+					testDb, "", "clan-search-clan", 10, nil,
 				)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(500 * time.Millisecond)
@@ -1198,7 +1200,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should return clan by short public ID as search term", func() {
-				dbClan, err := GetTestClanWithRandomPublicIDAndName(testDb, player.GameID, player.ID)
+				dbClan, err := fixtures.GetTestClanWithRandomPublicIDAndName(testDb, player.GameID, player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				searchClanID := dbClan.PublicID[:8]
 				Eventually(func() ([]Clan, error) { return SearchClan(testDb, testMongo, player.GameID, searchClanID, 10) }).Should(HaveLen(1))
@@ -1219,7 +1221,7 @@ var _ = Describe("Clan Model", func() {
 			It("Should return clan by word prefix", func() {
 				err := testing.CreateClanNameTextIndexInMongo(GetTestMongo, player.GameID)
 				Expect(err).NotTo(HaveOccurred())
-				dbClan, err := GetTestClanWithName(testDb, player.GameID, "The Largest Clan Name For Prefix Test", player.ID)
+				dbClan, err := fixtures.GetTestClanWithName(testDb, player.GameID, "The Largest Clan Name For Prefix Test", player.ID)
 				Eventually(func() (string, error) {
 					clans, err := SearchClan(testDb, testMongo, player.GameID, "prefi large", 10)
 					if err != nil {
@@ -1235,12 +1237,12 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get Clan and Owner", func() {
 			It("Should return clan and owner", func() {
-				_, clan, owner, _, _, err := GetClanWithMemberships(
+				_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(
 					testDb, 10, 3, 4, 5, "", "",
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				dbClan, dbOwner, err := GetClanAndOwnerByPublicID(testDb, GetEncryptionKey(), clan.GameID, clan.PublicID)
+				dbClan, dbOwner, err := GetClanAndOwnerByPublicID(testDb, fixtures.GetEncryptionKey(), clan.GameID, clan.PublicID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbClan.ID).To(Equal(clan.ID))
 				Expect(dbOwner.ID).To(Equal(owner.ID))

--- a/models/clan_test.go
+++ b/models/clan_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Clan Model", func() {
 		testMongo, err = GetTestMongo()
 		Expect(err).NotTo(HaveOccurred())
 
-		_, _ = ConfigureAndStartGoWorkers()
+		fixtures.ConfigureAndStartGoWorkers()
 
 		faultyDb = GetFaultyTestDB()
 	})
@@ -50,7 +50,7 @@ var _ = Describe("Clan Model", func() {
 		Describe("Basic Operations", func() {
 			It("Should sort clans by name", func() {
 				gameID := uuid.NewV4().String()
-				_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, nil)
+				_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 
 				sort.Sort(ClanByName(clans))
@@ -61,7 +61,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should create a new Clan", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 				Expect(clan.ID).NotTo(BeEquivalentTo(0))
@@ -74,7 +74,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should update a Clan", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -91,7 +91,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Id", func() {
 			It("Should get existing Clan", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -109,7 +109,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Public Id", func() {
 			It("Should get an existing Clan by Game and PublicID", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -127,7 +127,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Public Id", func() {
 			It("Should get an existing Clan by Game and PublicID prefix", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -214,7 +214,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Public Id and OwnerPublicID", func() {
 			It("Should get an existing Clan by Game, PublicID and OwnerPublicID", func() {
-				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -234,7 +234,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not get a existing Clan by Game, PublicID and OwnerPublicID if not Clan owner", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -412,7 +412,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Update Clan", func() {
 			It("Should update a Clan with UpdateClan", func() {
-				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -443,7 +443,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not update a Clan if player is not the clan owner with UpdateClan", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -472,7 +472,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not update a Clan with Invalid Data with UpdateClan", func() {
-				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -493,7 +493,7 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			Measure("Should update a Clan with UpdateClan", func(b Benchmarker) {
-				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, nil)
+				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -735,7 +735,7 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get List of Clans", func() {
 			It("Should get all clans", func() {
-				player, _, err := fixtures.CreateTestClans(testDb, "", "", 10, nil)
+				player, _, err := fixtures.CreateTestClans(testDb, "", "", 10, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 
 				clans, err := GetAllClans(testDb, player.GameID)
@@ -1176,7 +1176,7 @@ var _ = Describe("Clan Model", func() {
 			BeforeEach(func() {
 				var err error
 				player, realClans, err = fixtures.CreateTestClans(
-					testDb, "", "clan-search-clan", 10, nil,
+					testDb, "", "clan-search-clan", 10, fixtures.EnqueueClanForMongoUpdate,
 				)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(500 * time.Millisecond)

--- a/models/fixtures/fixtures.go
+++ b/models/fixtures/fixtures.go
@@ -5,7 +5,7 @@
 // http://www.opensource.org/licenses/mit-license
 // Copyright © 2016 Top Free Games <backend@tfgco.com>
 
-package models
+package fixtures
 
 import (
 	"database/sql"
@@ -15,12 +15,13 @@ import (
 	"github.com/Pallinder/go-randomdata"
 	"github.com/bluele/factory-go/factory"
 	uuid "github.com/satori/go.uuid"
+	"github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/util"
 )
 
 // GameFactory is responsible for constructing test game instances
 var GameFactory = factory.NewFactory(
-	&Game{
+	&models.Game{
 		MinLevelToAcceptApplication:   2,
 		MinLevelToCreateInvitation:    2,
 		MinLevelToRemoveMember:        2,
@@ -47,17 +48,17 @@ var GameFactory = factory.NewFactory(
 
 // HookFactory is responsible for constructing event hook instances
 var HookFactory = factory.NewFactory(
-	&Hook{EventType: GameUpdatedHook, URL: "http://test/game-created"},
+	&models.Hook{EventType: models.GameUpdatedHook, URL: "http://test/game-created"},
 )
 
 // CreateHookFactory is responsible for creating a test hook instance with the associated game
-func CreateHookFactory(db DB, gameID string, eventType int, url string) (*Hook, error) {
+func CreateHookFactory(db models.DB, gameID string, eventType int, url string) (*models.Hook, error) {
 	if gameID == "" {
 		gameID = uuid.NewV4().String()
 	}
 	game := GameFactory.MustCreateWithOption(map[string]interface{}{
 		"PublicID": gameID,
-	}).(*Game)
+	}).(*models.Game)
 	err := db.Insert(game)
 	if err != nil {
 		return nil, err
@@ -68,7 +69,7 @@ func CreateHookFactory(db DB, gameID string, eventType int, url string) (*Hook, 
 		"PublicID":  uuid.NewV4().String(),
 		"EventType": eventType,
 		"URL":       url,
-	}).(*Hook)
+	}).(*models.Hook)
 	err = db.Insert(hook)
 	if err != nil {
 		return nil, err
@@ -77,14 +78,14 @@ func CreateHookFactory(db DB, gameID string, eventType int, url string) (*Hook, 
 }
 
 // GetHooksForRoutes gets hooks for all the specified routes
-func GetHooksForRoutes(db DB, routes []string, eventType int) ([]*Hook, error) {
-	var hooks []*Hook
+func GetHooksForRoutes(db models.DB, routes []string, eventType int) ([]*models.Hook, error) {
+	var hooks []*models.Hook
 
 	gameID := uuid.NewV4().String()
 
 	game := GameFactory.MustCreateWithOption(map[string]interface{}{
 		"PublicID": gameID,
-	}).(*Game)
+	}).(*models.Game)
 	err := db.Insert(game)
 	if err != nil {
 		return nil, err
@@ -96,7 +97,7 @@ func GetHooksForRoutes(db DB, routes []string, eventType int) ([]*Hook, error) {
 			"PublicID":  uuid.NewV4().String(),
 			"EventType": eventType,
 			"URL":       route,
-		}).(*Hook)
+		}).(*models.Hook)
 		err := db.Insert(hook)
 		if err != nil {
 			return nil, err
@@ -126,17 +127,17 @@ func GetEncryptionKey() []byte {
 
 // PlayerFactory is responsible for constructing test player instances
 var PlayerFactory = configureFactory(factory.NewFactory(
-	&Player{},
+	&models.Player{},
 ))
 
 // ClanFactory is responsible for constructing test clan instances
 var ClanFactory = configureFactory(factory.NewFactory(
-	&Clan{},
+	&models.Clan{},
 ))
 
 // CreatePlayerFactory is responsible for creating a test player instance with the associated game
-func CreatePlayerFactory(db DB, gameID string, skipCreateGame ...bool) (*Game, *Player, error) {
-	var game *Game
+func CreatePlayerFactory(db models.DB, gameID string, skipCreateGame ...bool) (*models.Game, *models.Player, error) {
+	var game *models.Game
 
 	if skipCreateGame == nil || len(skipCreateGame) != 1 || !skipCreateGame[0] {
 		if gameID == "" {
@@ -144,14 +145,14 @@ func CreatePlayerFactory(db DB, gameID string, skipCreateGame ...bool) (*Game, *
 		}
 		game = GameFactory.MustCreateWithOption(map[string]interface{}{
 			"PublicID": gameID,
-		}).(*Game)
+		}).(*models.Game)
 		err := db.Insert(game)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else {
 		var err error
-		game, err = GetGameByPublicID(db, gameID)
+		game, err = models.GetGameByPublicID(db, gameID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -159,7 +160,7 @@ func CreatePlayerFactory(db DB, gameID string, skipCreateGame ...bool) (*Game, *
 
 	player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID": gameID,
-	}).(*Player)
+	}).(*models.Player)
 	err := db.Insert(player)
 	if err != nil {
 		return nil, nil, err
@@ -169,11 +170,11 @@ func CreatePlayerFactory(db DB, gameID string, skipCreateGame ...bool) (*Game, *
 
 // MembershipFactory is responsible for constructing test membership instances
 var MembershipFactory = factory.NewFactory(
-	&Membership{},
+	&models.Membership{},
 ).SeqInt("GameID", func(n int) (interface{}, error) {
 	return fmt.Sprintf("game-%d", n), nil
 }).Attr("ApproverID", func(args factory.Args) (interface{}, error) {
-	membership := args.Instance().(*Membership)
+	membership := args.Instance().(*models.Membership)
 	approverID := int64(0)
 	valid := false
 	if membership.Approved {
@@ -182,7 +183,7 @@ var MembershipFactory = factory.NewFactory(
 	}
 	return sql.NullInt64{Int64: int64(approverID), Valid: valid}, nil
 }).Attr("DenierID", func(args factory.Args) (interface{}, error) {
-	membership := args.Instance().(*Membership)
+	membership := args.Instance().(*models.Membership)
 	denierID := int64(0)
 	valid := false
 	if membership.Denied {
@@ -194,8 +195,8 @@ var MembershipFactory = factory.NewFactory(
 
 // GetClanWithMemberships returns a clan filled with the number of memberships specified
 func GetClanWithMemberships(
-	db DB, approvedMemberships, deniedMemberships, bannedMemberships, pendingMemberships int, gameID string, clanPublicID string, options ...bool) (*Game, *Clan, *Player, []*Player, []*Membership, error) {
-	var game *Game
+	db models.DB, approvedMemberships, deniedMemberships, bannedMemberships, pendingMemberships int, gameID string, clanPublicID string, options ...bool) (*models.Game, *models.Clan, *models.Player, []*models.Player, []*models.Membership, error) {
+	var game *models.Game
 
 	pendingsAreInvites := true
 	if options != nil && len(options) > 1 {
@@ -208,14 +209,14 @@ func GetClanWithMemberships(
 		}
 		game = GameFactory.MustCreateWithOption(map[string]interface{}{
 			"PublicID": gameID,
-		}).(*Game)
+		}).(*models.Game)
 		err := db.Insert(game)
 		if err != nil {
 			return nil, nil, nil, nil, nil, err
 		}
 	} else {
 		var err error
-		game, err = GetGameByPublicID(db, gameID)
+		game, err = models.GetGameByPublicID(db, gameID)
 		if err != nil {
 			return nil, nil, nil, nil, nil, err
 		}
@@ -227,7 +228,7 @@ func GetClanWithMemberships(
 	owner := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":         gameID,
 		"OwnershipCount": 1,
-	}).(*Player)
+	}).(*models.Player)
 	err := db.Insert(owner)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
@@ -240,32 +241,32 @@ func GetClanWithMemberships(
 		"Metadata":         map[string]interface{}{"x": "a"},
 		"MembershipCount":  approvedMemberships + 1,
 		"AllowApplication": true,
-	}).(*Clan)
+	}).(*models.Clan)
 	err = db.Insert(clan)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
 	testData := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"approved": true,
 			"denied":   false,
 			"banned":   false,
 			"count":    approvedMemberships,
 		},
-		map[string]interface{}{
+		{
 			"approved": false,
 			"denied":   true,
 			"banned":   false,
 			"count":    deniedMemberships,
 		},
-		map[string]interface{}{
+		{
 			"approved": false,
 			"denied":   false,
 			"banned":   true,
 			"count":    bannedMemberships,
 		},
-		map[string]interface{}{
+		{
 			"approved": false,
 			"denied":   false,
 			"banned":   false,
@@ -273,8 +274,8 @@ func GetClanWithMemberships(
 		},
 	}
 
-	var players []*Player
-	var memberships []*Membership
+	var players []*models.Player
+	var memberships []*models.Membership
 
 	for _, data := range testData {
 		approved := data["approved"].(bool)
@@ -290,7 +291,7 @@ func GetClanWithMemberships(
 			player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 				"GameID":          owner.GameID,
 				"MembershipCount": membershipCount,
-			}).(*Player)
+			}).(*models.Player)
 			err = db.Insert(player)
 			if err != nil {
 				return nil, nil, nil, nil, nil, err
@@ -315,7 +316,7 @@ func GetClanWithMemberships(
 				"Denied":      denied,
 				"Banned":      banned,
 				"Message":     message,
-			}).(*Membership)
+			}).(*models.Membership)
 
 			if approved {
 				approverID := player.ID
@@ -358,14 +359,14 @@ func GetClanWithMemberships(
 }
 
 // GetClanReachedMaxMemberships returns a clan with one approved membership, one unapproved membership and game MaxMembers=1
-func GetClanReachedMaxMemberships(db DB) (*Game, *Clan, *Player, []*Player, []*Membership, error) {
+func GetClanReachedMaxMemberships(db models.DB) (*models.Game, *models.Clan, *models.Player, []*models.Player, []*models.Membership, error) {
 	gameID := uuid.NewV4().String()
 	clanPublicID := uuid.NewV4().String()
 
 	game := GameFactory.MustCreateWithOption(map[string]interface{}{
 		"PublicID":   gameID,
 		"MaxMembers": 1,
-	}).(*Game)
+	}).(*models.Game)
 	err := db.Insert(game)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
@@ -374,13 +375,13 @@ func GetClanReachedMaxMemberships(db DB) (*Game, *Clan, *Player, []*Player, []*M
 	owner := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":         gameID,
 		"OwnershipCount": 1,
-	}).(*Player)
+	}).(*models.Player)
 	err = db.Insert(owner)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
-	var players []*Player
+	var players []*models.Player
 
 	for i := 0; i < 2; i++ {
 		membershipCount := 0
@@ -390,7 +391,7 @@ func GetClanReachedMaxMemberships(db DB) (*Game, *Clan, *Player, []*Player, []*M
 		player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 			"GameID":          owner.GameID,
 			"MembershipCount": membershipCount,
-		}).(*Player)
+		}).(*models.Player)
 		err = db.Insert(player)
 		if err != nil {
 			return nil, nil, nil, nil, nil, err
@@ -404,13 +405,13 @@ func GetClanReachedMaxMemberships(db DB) (*Game, *Clan, *Player, []*Player, []*M
 		"OwnerID":         owner.ID,
 		"Metadata":        map[string]interface{}{"x": "a"},
 		"MembershipCount": 2,
-	}).(*Clan)
+	}).(*models.Clan)
 	err = db.Insert(clan)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
-	var memberships []*Membership
+	var memberships []*models.Membership
 
 	membership := MembershipFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":      owner.GameID,
@@ -422,7 +423,7 @@ func GetClanReachedMaxMemberships(db DB) (*Game, *Clan, *Player, []*Player, []*M
 		"Level":       "Member",
 		"ApproverID":  sql.NullInt64{Int64: int64(players[0].ID), Valid: true},
 		"ApprovedAt":  util.NowMilli(),
-	}).(*Membership)
+	}).(*models.Membership)
 	err = db.Insert(membership)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
@@ -437,7 +438,7 @@ func GetClanReachedMaxMemberships(db DB) (*Game, *Clan, *Player, []*Player, []*M
 		"Metadata":    map[string]interface{}{"x": "a"},
 		"Approved":    false,
 		"Level":       "Member",
-	}).(*Membership)
+	}).(*models.Membership)
 	err = db.Insert(membership)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
@@ -448,13 +449,13 @@ func GetClanReachedMaxMemberships(db DB) (*Game, *Clan, *Player, []*Player, []*M
 }
 
 // GetTestClanWithRandomPublicIDAndName returns a clan with random UUID v4 publicID and name for tests
-func GetTestClanWithRandomPublicIDAndName(db DB, gameID string, ownerID int64) (*Clan, error) {
+func GetTestClanWithRandomPublicIDAndName(db models.DB, gameID string, ownerID int64) (*models.Clan, error) {
 	clan := ClanFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":   gameID,
 		"PublicID": uuid.NewV4().String(),
 		"Name":     uuid.NewV4().String(),
 		"OwnerID":  ownerID,
-	}).(*Clan)
+	}).(*models.Clan)
 	err := db.Insert(clan)
 	if err != nil {
 		return nil, err
@@ -467,13 +468,13 @@ func GetTestClanWithRandomPublicIDAndName(db DB, gameID string, ownerID int64) (
 }
 
 // GetTestClanWithName returns a clan with name for tests
-func GetTestClanWithName(db DB, gameID, name string, ownerID int64) (*Clan, error) {
+func GetTestClanWithName(db models.DB, gameID, name string, ownerID int64) (*models.Clan, error) {
 	clan := ClanFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":   gameID,
 		"PublicID": uuid.NewV4().String(),
 		"Name":     name,
 		"OwnerID":  ownerID,
-	}).(*Clan)
+	}).(*models.Clan)
 	err := db.Insert(clan)
 	if err != nil {
 		return nil, err
@@ -485,14 +486,19 @@ func GetTestClanWithName(db DB, gameID, name string, ownerID int64) (*Clan, erro
 	return clan, nil
 }
 
-// GetTestClans returns a list of clans for tests
-func GetTestClans(db DB, gameID string, publicIDTemplate string, numberOfClans int) (*Player, []*Clan, error) {
+// AfterClanCreationHook permits a caller to execute code after a test clan is created.
+type AfterClanCreationHook func(clan *models.Clan) error
+
+// CreateTestClans returns a list of clans for tests
+func CreateTestClans(
+	db models.DB, gameID string, publicIDTemplate string, numberOfClans int, afterCreationHook AfterClanCreationHook,
+) (*models.Player, []*models.Clan, error) {
 	if gameID == "" {
 		gameID = uuid.NewV4().String()
 	}
 	game := GameFactory.MustCreateWithOption(map[string]interface{}{
 		"PublicID": gameID,
-	}).(*Game)
+	}).(*models.Game)
 	err := db.Insert(game)
 	if err != nil {
 		return nil, nil, err
@@ -501,7 +507,7 @@ func GetTestClans(db DB, gameID string, publicIDTemplate string, numberOfClans i
 	player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":         gameID,
 		"OwnershipCount": numberOfClans,
-	}).(*Player)
+	}).(*models.Player)
 	err = db.Insert(player)
 	if err != nil {
 		return nil, nil, err
@@ -511,21 +517,23 @@ func GetTestClans(db DB, gameID string, publicIDTemplate string, numberOfClans i
 		publicIDTemplate = uuid.NewV4().String()
 	}
 
-	var clans []*Clan
+	var clans []*models.Clan
 	for i := 0; i < numberOfClans; i++ {
 		clan := ClanFactory.MustCreateWithOption(map[string]interface{}{
 			"GameID":   player.GameID,
 			"PublicID": fmt.Sprintf("%s-%d", publicIDTemplate, i),
 			"Name":     fmt.Sprintf("💩clán-%s-%d", publicIDTemplate, i),
 			"OwnerID":  player.ID,
-		}).(*Clan)
+		}).(*models.Clan)
 		err = db.Insert(clan)
 		if err != nil {
 			return nil, nil, err
 		}
-		err = clan.UpdateClanIntoMongoDB()
-		if err != nil {
-			return nil, nil, err
+		if afterCreationHook != nil {
+			err = afterCreationHook(clan)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 
 		clans = append(clans, clan)
@@ -535,16 +543,16 @@ func GetTestClans(db DB, gameID string, publicIDTemplate string, numberOfClans i
 }
 
 // GetTestHooks return a fixed number of hooks for each event available
-func GetTestHooks(db DB, gameID string, numberOfHooks int) ([]*Hook, error) {
+func GetTestHooks(db models.DB, gameID string, numberOfHooks int) ([]*models.Hook, error) {
 	game := GameFactory.MustCreateWithOption(map[string]interface{}{
 		"PublicID": gameID,
-	}).(*Game)
+	}).(*models.Game)
 	err := db.Insert(game)
 	if err != nil {
 		return nil, err
 	}
 
-	var hooks []*Hook
+	var hooks []*models.Hook
 	for i := 0; i < 2; i++ {
 		for j := 0; j < numberOfHooks; j++ {
 			hook := HookFactory.MustCreateWithOption(map[string]interface{}{
@@ -552,7 +560,7 @@ func GetTestHooks(db DB, gameID string, numberOfHooks int) ([]*Hook, error) {
 				"PublicID":  uuid.NewV4().String(),
 				"EventType": i,
 				"URL":       fmt.Sprintf("http://test/event-%d-%d", i, j),
-			}).(*Hook)
+			}).(*models.Hook)
 			err = db.Insert(hook)
 			if err != nil {
 				return nil, err
@@ -565,13 +573,13 @@ func GetTestHooks(db DB, gameID string, numberOfHooks int) ([]*Hook, error) {
 }
 
 //GetTestPlayerWithMemberships returns the clan owner, a player with approved, rejected, and banned memberships
-func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rejectedMemberships, bannedMemberships, pendingMemberships int) (*Player, *Player, error) {
+func GetTestPlayerWithMemberships(db models.DB, gameID string, approvedMemberships, rejectedMemberships, bannedMemberships, pendingMemberships int) (*models.Player, *models.Player, error) {
 	if gameID == "" {
 		gameID = uuid.NewV4().String()
 	}
 	game := GameFactory.MustCreateWithOption(map[string]interface{}{
 		"PublicID": gameID,
-	}).(*Game)
+	}).(*models.Game)
 	err := db.Insert(game)
 	if err != nil {
 		return nil, nil, err
@@ -580,7 +588,7 @@ func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rej
 	owner := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":         gameID,
 		"OwnershipCount": 1,
-	}).(*Player)
+	}).(*models.Player)
 	err = db.Insert(owner)
 	if err != nil {
 		return nil, nil, err
@@ -589,20 +597,20 @@ func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rej
 	player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":          owner.GameID,
 		"MembershipCount": approvedMemberships,
-	}).(*Player)
+	}).(*models.Player)
 	err = db.Insert(player)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	createClan := func() (*Clan, error) {
+	createClan := func() (*models.Clan, error) {
 		clan := ClanFactory.MustCreateWithOption(map[string]interface{}{
 			"GameID":          owner.GameID,
 			"PublicID":        uuid.NewV4().String(),
 			"OwnerID":         owner.ID,
 			"Metadata":        map[string]interface{}{"x": "a"},
 			"MembershipCount": approvedMemberships + 1,
-		}).(*Clan)
+		}).(*models.Clan)
 		err = db.Insert(clan)
 		if err != nil {
 			return nil, err
@@ -611,7 +619,7 @@ func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rej
 		return clan, nil
 	}
 
-	createMembership := func(approved, denied, banned bool) (*Membership, error) {
+	createMembership := func(approved, denied, banned bool) (*models.Membership, error) {
 		clan, err := createClan()
 		if err != nil {
 			return nil, err
@@ -639,7 +647,7 @@ func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rej
 			payload["DeniedAt"] = util.NowMilli()
 		}
 
-		membership := MembershipFactory.MustCreateWithOption(payload).(*Membership)
+		membership := MembershipFactory.MustCreateWithOption(payload).(*models.Membership)
 
 		err = db.Insert(membership)
 		if err != nil {
@@ -678,7 +686,7 @@ func GetTestPlayerWithMemberships(db DB, gameID string, approvedMemberships, rej
 }
 
 //GetTestClanWithStaleData returns a player with approved, rejected and banned memberships
-func GetTestClanWithStaleData(db DB, staleApplications, staleInvites, staleDenies, staleDeletes int) (string, error) {
+func GetTestClanWithStaleData(db models.DB, staleApplications, staleInvites, staleDenies, staleDeletes int) (string, error) {
 	gameID := uuid.NewV4().String()
 	game := GameFactory.MustCreateWithOption(map[string]interface{}{
 		"PublicID": gameID,
@@ -688,7 +696,7 @@ func GetTestClanWithStaleData(db DB, staleApplications, staleInvites, staleDenie
 			"deniedMembershipsExpiration":   3600,
 			"deletedMembershipsExpiration":  3600,
 		},
-	}).(*Game)
+	}).(*models.Game)
 	err := db.Insert(game)
 	if err != nil {
 		return "", err
@@ -697,7 +705,7 @@ func GetTestClanWithStaleData(db DB, staleApplications, staleInvites, staleDenie
 	owner := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 		"GameID":         gameID,
 		"OwnershipCount": 1,
-	}).(*Player)
+	}).(*models.Player)
 	err = db.Insert(owner)
 	if err != nil {
 		return "", err
@@ -708,16 +716,16 @@ func GetTestClanWithStaleData(db DB, staleApplications, staleInvites, staleDenie
 		"PublicID": uuid.NewV4().String(),
 		"OwnerID":  owner.ID,
 		"Metadata": map[string]interface{}{"x": "a"},
-	}).(*Clan)
+	}).(*models.Clan)
 	err = db.Insert(clan)
 	if err != nil {
 		return "", err
 	}
 
-	createMembership := func(createdAt int64, application bool, denied bool, deleted bool) (*Player, *Membership, error) {
+	createMembership := func(createdAt int64, application bool, denied bool, deleted bool) (*models.Player, *models.Membership, error) {
 		player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
 			"GameID": gameID,
-		}).(*Player)
+		}).(*models.Player)
 		err = db.Insert(player)
 		if err != nil {
 			return nil, nil, err
@@ -748,7 +756,7 @@ func GetTestClanWithStaleData(db DB, staleApplications, staleInvites, staleDenie
 			payload["DeletedAt"] = util.NowMilli()
 		}
 
-		membership := MembershipFactory.MustCreateWithOption(payload).(*Membership)
+		membership := MembershipFactory.MustCreateWithOption(payload).(*models.Membership)
 		err = db.Insert(membership)
 		if err != nil {
 			return nil, nil, err

--- a/models/game_test.go
+++ b/models/game_test.go
@@ -13,8 +13,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 )
 
 var _ = Describe("Game Model", func() {
@@ -29,7 +30,7 @@ var _ = Describe("Game Model", func() {
 	Describe("basic functionality", func() {
 		Describe("creating a new game", func() {
 			It("should create a game", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(game.ID).NotTo(Equal(0))
@@ -59,7 +60,7 @@ var _ = Describe("Game Model", func() {
 		})
 		Describe("updating new game", func() {
 			It("should update game", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -78,7 +79,7 @@ var _ = Describe("Game Model", func() {
 
 	Describe("getting game by ID", func() {
 		It("Should get existing Game", func() {
-			game := GameFactory.MustCreate().(*Game)
+			game := fixtures.GameFactory.MustCreate().(*Game)
 			err := testDb.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -96,7 +97,7 @@ var _ = Describe("Game Model", func() {
 
 	Describe("getting a game by ID", func() {
 		It("Should get existing Game", func() {
-			game := GameFactory.MustCreate().(*Game)
+			game := fixtures.GameFactory.MustCreate().(*Game)
 			err := testDb.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -114,7 +115,7 @@ var _ = Describe("Game Model", func() {
 
 	Describe("getting a game by Public ID", func() {
 		It("Should get existing Game by Game and Game", func() {
-			game := GameFactory.MustCreate().(*Game)
+			game := fixtures.GameFactory.MustCreate().(*Game)
 			err := testDb.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -208,7 +209,7 @@ var _ = Describe("Game Model", func() {
 
 	Describe("Update Game", func() {
 		It("Should update a Game with UpdateGame", func() {
-			game := GameFactory.MustCreate().(*Game)
+			game := fixtures.GameFactory.MustCreate().(*Game)
 			err := testDb.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -293,7 +294,7 @@ var _ = Describe("Game Model", func() {
 		})
 
 		It("Should not update a Game with Invalid Data with UpdateGame", func() {
-			game := GameFactory.MustCreate().(*Game)
+			game := fixtures.GameFactory.MustCreate().(*Game)
 			err := testDb.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -314,7 +315,7 @@ var _ = Describe("Game Model", func() {
 
 	Describe("Get All Games", func() {
 		It("Should get all games", func() {
-			game := GameFactory.MustCreate().(*Game)
+			game := fixtures.GameFactory.MustCreate().(*Game)
 			err := testDb.Insert(game)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/models/helpers_test.go
+++ b/models/helpers_test.go
@@ -45,13 +45,13 @@ func GetFaultyTestDB() models.DB {
 	return faultyDb
 }
 
-func ConfigureAndStartGoWorkers() error {
+func ConfigureAndStartGoWorkers() (*models.MongoWorker, error) {
 	config := viper.New()
 	config.SetConfigType("yaml")
 	config.SetConfigFile("../config/test.yaml")
 	err := config.ReadInConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	redisHost := config.GetString("redis.host")
@@ -87,5 +87,5 @@ func ConfigureAndStartGoWorkers() error {
 	mongoWorker := models.NewMongoWorker(logger, config)
 	workers.Process(queues.KhanMongoQueue, mongoWorker.PerformUpdateMongo, workerCount)
 	workers.Start()
-	return nil
+	return mongoWorker, nil
 }

--- a/models/hook_test.go
+++ b/models/hook_test.go
@@ -12,8 +12,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 )
 
 var _ = Describe("Hook Model", func() {
@@ -29,7 +30,7 @@ var _ = Describe("Hook Model", func() {
 
 		Describe("Model Basic Tests", func() {
 			It("Should create a new Hook", func() {
-				hook, err := CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/created")
+				hook, err := fixtures.CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/created")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hook.ID).NotTo(BeEquivalentTo(0))
 
@@ -42,7 +43,7 @@ var _ = Describe("Hook Model", func() {
 			})
 
 			It("Should update a Hook", func() {
-				hook, err := CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/updated")
+				hook, err := fixtures.CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/updated")
 				Expect(err).NotTo(HaveOccurred())
 				dt := hook.UpdatedAt
 				hook.URL = "http://test/updated2"
@@ -59,7 +60,7 @@ var _ = Describe("Hook Model", func() {
 
 		Describe("Get Hook By ID", func() {
 			It("Should get existing Hook", func() {
-				hook, err := CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/getbyid")
+				hook, err := fixtures.CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/getbyid")
 				Expect(err).NotTo(HaveOccurred())
 
 				dbHook, err := GetHookByID(testDb, hook.ID)
@@ -76,7 +77,7 @@ var _ = Describe("Hook Model", func() {
 
 		Describe("Get Hook By Public ID", func() {
 			It("Should get existing Hook", func() {
-				hook, err := CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/getbyid")
+				hook, err := fixtures.CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/getbyid")
 				Expect(err).NotTo(HaveOccurred())
 
 				dbHook, err := GetHookByPublicID(testDb, hook.GameID, hook.PublicID)
@@ -93,7 +94,7 @@ var _ = Describe("Hook Model", func() {
 
 		Describe("Create Hook", func() {
 			It("Should create a new Hook with CreateHook", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -116,7 +117,7 @@ var _ = Describe("Hook Model", func() {
 
 			It("Create same Hook works fine", func() {
 				gameID := uuid.NewV4().String()
-				hook, err := CreateHookFactory(testDb, gameID, GameUpdatedHook, "http://test/created")
+				hook, err := fixtures.CreateHookFactory(testDb, gameID, GameUpdatedHook, "http://test/created")
 
 				hook2, err := CreateHook(
 					testDb,
@@ -139,7 +140,7 @@ var _ = Describe("Hook Model", func() {
 
 		Describe("Remove Hook", func() {
 			It("Should remove a Hook with RemoveHook", func() {
-				hook, err := CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/update")
+				hook, err := fixtures.CreateHookFactory(testDb, "", GameUpdatedHook, "http://test/update")
 				Expect(err).NotTo(HaveOccurred())
 
 				err = RemoveHook(
@@ -159,7 +160,7 @@ var _ = Describe("Hook Model", func() {
 		Describe("Get All Hooks", func() {
 			It("Should get all hooks", func() {
 				gameID := uuid.NewV4().String()
-				_, err := GetTestHooks(testDb, gameID, 5)
+				_, err := fixtures.GetTestHooks(testDb, gameID, 5)
 				Expect(err).NotTo(HaveOccurred())
 
 				hooks, err := GetAllHooks(testDb)

--- a/models/membership_test.go
+++ b/models/membership_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 	uuid "github.com/satori/go.uuid"
 	. "github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	"github.com/topfreegames/khan/util"
 )
 
@@ -31,7 +32,7 @@ var _ = Describe("Membership Model", func() {
 	Describe("Membership Model", func() {
 		Describe("Get Number of Pending Invites", func() {
 			It("Should get number of pending invites", func() {
-				_, player, err := GetTestPlayerWithMemberships(testDb, uuid.NewV4().String(), 0, 0, 0, 20)
+				_, player, err := fixtures.GetTestPlayerWithMemberships(testDb, uuid.NewV4().String(), 0, 0, 0, 20)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(player).NotTo(BeEquivalentTo(nil))
 
@@ -42,7 +43,7 @@ var _ = Describe("Membership Model", func() {
 		})
 		Describe("Create Membership", func() {
 			It("Should create a new Membership", func() {
-				_, _, _, _, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				_, _, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				membership := memberships[0]
@@ -59,7 +60,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Should not create a new membership for a member with max number of invitations", func() {
 				gameID := uuid.NewV4().String()
-				_, player, err := GetTestPlayerWithMemberships(testDb, gameID, 0, 0, 0, 20)
+				_, player, err := fixtures.GetTestPlayerWithMemberships(testDb, gameID, 0, 0, 0, 20)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(player).NotTo(BeEquivalentTo(nil))
 
@@ -67,13 +68,13 @@ var _ = Describe("Membership Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(game).NotTo(BeEquivalentTo(nil))
 
-				_, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, gameID, "", true)
+				_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, gameID, "", true)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clan).NotTo(BeEquivalentTo(nil))
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -93,7 +94,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should not create a new membership for the clan owner", func() {
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clan).NotTo(BeEquivalentTo(nil))
 
@@ -103,7 +104,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -124,7 +125,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Should create a new membership for a member when game MaxPendingInvites is -1", func() {
 				gameID := uuid.NewV4().String()
-				_, player, err := GetTestPlayerWithMemberships(testDb, gameID, 0, 0, 0, 20)
+				_, player, err := fixtures.GetTestPlayerWithMemberships(testDb, gameID, 0, 0, 0, 20)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(player).NotTo(BeEquivalentTo(nil))
 
@@ -135,13 +136,13 @@ var _ = Describe("Membership Model", func() {
 				_, err = testDb.Update(game)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, gameID, "", true)
+				_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, gameID, "", true)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(clan).NotTo(BeEquivalentTo(nil))
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -158,14 +159,14 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should allow users to recreate an invitation if no cooldown", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 				membership := memberships[0]
 				Expect(membership.ID).NotTo(BeEquivalentTo(0))
 
 				updMembership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					players[0].PublicID,
@@ -184,19 +185,19 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should allow users to recreate an application if no cooldown", func() {
-				game, clan, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownBeforeApply = 0
 				_, err = testDb.Update(game)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, player, err := CreatePlayerFactory(testDb, game.PublicID, true)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, game.PublicID, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -208,7 +209,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -227,15 +228,15 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should fail if user re-applies before cooldown", func() {
-				game, clan, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				_, player, err := CreatePlayerFactory(testDb, game.PublicID, true)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, game.PublicID, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -247,7 +248,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -260,15 +261,15 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should allow users to recreate an invitation if no cooldown", func() {
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				_, player, err := CreatePlayerFactory(testDb, game.PublicID, true)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, game.PublicID, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -280,7 +281,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -299,19 +300,19 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should fail if user to be re-invited before cooldown", func() {
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownBeforeInvite = 1000
 				_, err = testDb.Update(game)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, player, err := CreatePlayerFactory(testDb, game.PublicID, true)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, game.PublicID, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -323,7 +324,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -336,7 +337,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should allow users to create an application after an invitation if no cooldown", func() {
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownBeforeInvite = 1000
@@ -344,12 +345,12 @@ var _ = Describe("Membership Model", func() {
 				_, err = testDb.Update(game)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, player, err := CreatePlayerFactory(testDb, game.PublicID, true)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, game.PublicID, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -361,7 +362,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -380,7 +381,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should allow users to create an invitation after an application if no cooldown", func() {
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownBeforeInvite = 0
@@ -388,12 +389,12 @@ var _ = Describe("Membership Model", func() {
 				_, err = testDb.Update(game)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, player, err := CreatePlayerFactory(testDb, game.PublicID, true)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, game.PublicID, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -405,7 +406,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -424,7 +425,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should not fail if an application after an invitation has cooldown", func() {
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownBeforeInvite = 2000
@@ -437,12 +438,12 @@ var _ = Describe("Membership Model", func() {
 				_, err = testDb.Update(clan)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, player, err := CreatePlayerFactory(testDb, game.PublicID, true)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, game.PublicID, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -454,7 +455,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -475,7 +476,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should not fail if an invitation after an application has cooldown", func() {
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownBeforeInvite = 2000
@@ -483,12 +484,12 @@ var _ = Describe("Membership Model", func() {
 				_, err = testDb.Update(game)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, player, err := CreatePlayerFactory(testDb, game.PublicID, true)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, game.PublicID, true)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -500,7 +501,7 @@ var _ = Describe("Membership Model", func() {
 
 				updMembership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game, game.PublicID,
 					"Member",
 					player.PublicID,
@@ -522,7 +523,7 @@ var _ = Describe("Membership Model", func() {
 		})
 
 		It("Should update a Membership", func() {
-			_, _, _, _, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, _, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 			dt := memberships[0].UpdatedAt
 
@@ -535,7 +536,7 @@ var _ = Describe("Membership Model", func() {
 		})
 
 		It("Should get existing Membership", func() {
-			_, _, _, _, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, _, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			dbMembership, err := GetMembershipByID(testDb, memberships[0].ID)
@@ -550,7 +551,7 @@ var _ = Describe("Membership Model", func() {
 		})
 
 		It("Should get an existing Membership by the player public ID", func() {
-			_, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			dbMembership, err := GetValidMembershipByClanAndPlayerPublicID(testDb, players[0].GameID, clan.PublicID, players[0].PublicID)
@@ -561,10 +562,10 @@ var _ = Describe("Membership Model", func() {
 
 		Describe("Should not get Membership by the player public ID", func() {
 			It("If non-existing Membership", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				clan := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				clan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":  player.GameID,
 					"OwnerID": player.ID,
 				}).(*Clan)
@@ -578,7 +579,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If Membership was deleted", func() {
-				_, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				_, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].DeletedAt = util.NowMilli()
@@ -593,7 +594,7 @@ var _ = Describe("Membership Model", func() {
 		})
 
 		It("Should get a deleted Membership by the clan ID and player private ID using GetDeletedMembershipByClanAndPlayerID", func() {
-			_, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].DeletedAt = util.NowMilli()
@@ -609,7 +610,7 @@ var _ = Describe("Membership Model", func() {
 		})
 
 		It("Should get a deleted Membership by the clan and player public ID using GetMembershipByClanAndPlayerPublicID", func() {
-			_, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+			_, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			memberships[0].DeletedAt = util.NowMilli()
@@ -625,7 +626,7 @@ var _ = Describe("Membership Model", func() {
 		})
 
 		It("Should get a denied Membership by the player public ID using GetMembershipByClanAndPlayerPublicID", func() {
-			_, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 1, 0, 0, "", "")
+			_, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 1, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			dbMembership, err := GetMembershipByClanAndPlayerPublicID(testDb, clan.GameID, clan.PublicID, players[0].PublicID)
@@ -636,7 +637,7 @@ var _ = Describe("Membership Model", func() {
 
 		Describe("GetOldestMemberWithHighestLevel", func() {
 			It("Should get the approved member with the highest level", func() {
-				_, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 2, 0, 0, 0, "", "")
+				_, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 2, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Level = "CoLeader"
@@ -649,7 +650,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should not get pending memberships", func() {
-				_, clan, _, _, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				_, clan, _, _, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Level = "CoLeader"
@@ -662,7 +663,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Should return an error if clan has no members", func() {
-				_, clan, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				_, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				dbMembership, err := GetOldestMemberWithHighestLevel(testDb, clan.GameID, clan.PublicID)
@@ -681,14 +682,14 @@ var _ = Describe("Membership Model", func() {
 
 		Describe("Should create a new Membership with CreateMembership", func() {
 			It("If requestor is the player and clan.AllowApplication = true", func() {
-				game, clan, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				clan.AllowApplication = true
 				_, err = testDb.Update(clan)
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -696,7 +697,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -720,7 +721,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -730,7 +731,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor is the player and clan.AllowApplication = true and previous deleted membership", func() {
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownBeforeApply = 0
@@ -754,7 +755,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -778,7 +779,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.DeletedAt).To(Equal(int64(0)))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), players[0].ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), players[0].ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -788,7 +789,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("And approve it automatically if requestor is the player, clan.AllowApplication=true and clan.AutoJoin=true", func() {
-				game, clan, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				clan.AllowApplication = true
@@ -796,7 +797,7 @@ var _ = Describe("Membership Model", func() {
 				_, err = testDb.Update(clan)
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -804,7 +805,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -828,7 +829,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -838,10 +839,10 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor is the clan owner", func() {
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -849,7 +850,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -875,10 +876,10 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor is a member of the clan with level greater than the min level", func() {
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -892,7 +893,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -918,7 +919,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If deleted previous membership", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].DeletedAt = util.NowMilli()
@@ -930,7 +931,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -954,7 +955,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -964,7 +965,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If deleted previous membership, after waiting cooldown seconds", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownAfterDelete = 1
@@ -981,7 +982,7 @@ var _ = Describe("Membership Model", func() {
 				time.Sleep(time.Second)
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1005,7 +1006,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -1015,7 +1016,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If deleted previous membership and deleter is not the membership player and requestor is not membership player before waiting cooldown seconds", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownAfterDelete = 10
@@ -1031,7 +1032,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1058,7 +1059,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If denied previous membership and denier is the membership player, before waiting cooldown seconds", func() {
-				game, clan, owner, players, _, err := GetClanWithMemberships(testDb, 0, 1, 0, 0, "", "")
+				game, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 1, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownAfterDeny = 10
@@ -1067,7 +1068,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1081,7 +1082,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If denied previous membership, after waiting cooldown seconds", func() {
-				game, clan, owner, players, _, err := GetClanWithMemberships(testDb, 0, 1, 0, 0, "", "")
+				game, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 1, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownAfterDeny = 1
@@ -1091,7 +1092,7 @@ var _ = Describe("Membership Model", func() {
 				time.Sleep(time.Second)
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1114,7 +1115,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -1124,7 +1125,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If deleted previous membership and deleter is the membership player, before waiting cooldown seconds", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownAfterDelete = 10
@@ -1140,7 +1141,7 @@ var _ = Describe("Membership Model", func() {
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1164,7 +1165,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.Message).To(Equal("Please accept me"))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -1175,13 +1176,13 @@ var _ = Describe("Membership Model", func() {
 
 			It("If denied previous membership request and clan autoJoin is changed to true, before waiting cooldown seconds", func() {
 				// create a pending membership application
-				game, clan, owner, players, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "", false, false)
+				game, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "", false, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				// deny application
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1204,7 +1205,7 @@ var _ = Describe("Membership Model", func() {
 				// apply for membership again
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1222,7 +1223,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Approved).To(BeTrue())
 				Expect(dbMembership.Denied).To(Equal(false))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), dbMembership.PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), dbMembership.PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -1234,7 +1235,7 @@ var _ = Describe("Membership Model", func() {
 
 		Describe("Should not create a new Membership with CreateMembership if", func() {
 			It("If deleted previous membership and deleter is not the membership player and requestor is the membership player before waiting cooldown seconds", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownAfterDelete = 10
@@ -1250,7 +1251,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1265,7 +1266,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If denied previous membership and denier is not the membership player, before waiting cooldown seconds", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 1, 0, 0, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 1, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.CooldownAfterDeny = 10
@@ -1278,7 +1279,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					"Member",
@@ -1293,10 +1294,10 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If clan reached the game's MaxMembers", func() {
-				game, clan, owner, _, _, err := GetClanReachedMaxMemberships(testDb)
+				game, clan, owner, _, _, err := fixtures.GetClanReachedMaxMemberships(testDb)
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -1304,7 +1305,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1319,10 +1320,10 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If player reached the game's MaxClansPerPlayer (member of another clans)", func() {
-				game, _, owner, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, _, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				anotherClan := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				anotherClan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":   owner.GameID,
 					"PublicID": uuid.NewV4().String(),
 					"OwnerID":  owner.ID,
@@ -1333,7 +1334,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -1348,10 +1349,10 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If player reached the game's MaxClansPerPlayer (owner of another clan)", func() {
-				game, _, owner, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, _, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				anotherClan := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				anotherClan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":   players[0].GameID,
 					"PublicID": uuid.NewV4().String(),
 					"OwnerID":  players[0].ID,
@@ -1362,7 +1363,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					game.PublicID,
 					"Member",
@@ -1377,14 +1378,14 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor is the player and clan.AllowApplication = false", func() {
-				game, clan, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				clan.AllowApplication = false
 				_, err = testDb.Update(clan)
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -1392,7 +1393,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1408,14 +1409,14 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Unexistent player", func() {
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				playerPublicID := randomdata.FullName(randomdata.RandomGender)
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					owner.GameID,
 					"Member",
@@ -1430,13 +1431,13 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Unexistent clan", func() {
-				game, player, err := CreatePlayerFactory(testDb, "")
+				game, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				clanPublicID := randomdata.FullName(randomdata.RandomGender)
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1452,10 +1453,10 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Unexistent requestor", func() {
-				game, clan, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -1464,7 +1465,7 @@ var _ = Describe("Membership Model", func() {
 				requestorPublicID := randomdata.FullName(randomdata.RandomGender)
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1479,16 +1480,16 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Requestor is not clan member/owner", func() {
-				game, clan, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
 				Expect(err).NotTo(HaveOccurred())
 
-				requestor := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				requestor := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(requestor)
@@ -1496,7 +1497,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1512,10 +1513,10 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Requestor's level is less than min level", func() {
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -1523,7 +1524,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					"Member",
@@ -1538,12 +1539,12 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("Membership already exists", func() {
-				game, clan, owner, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				membership, err := CreateMembership(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					clan.GameID,
 					"Member",
@@ -1562,12 +1563,12 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should approve a Membership invitation with ApproveOrDenyMembershipInvitation if", func() {
 			It("Player is not the membership requestor", func() {
 				action := "approve"
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				updatedMembership, err := ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1588,7 +1589,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.ApproverID.Valid).To(BeTrue())
 				Expect(dbMembership.ApproverID.Int64).To(Equal(int64(players[0].ID)))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), players[0].ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), players[0].ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -1601,12 +1602,12 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should not approve a Membership invitation with ApproveOrDenyMembershipInvitation if", func() {
 			It("If clan reached the game's MaxMembers", func() {
 				action := "approve"
-				game, clan, _, players, _, err := GetClanReachedMaxMemberships(testDb)
+				game, clan, _, players, _, err := fixtures.GetClanReachedMaxMemberships(testDb)
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[1].GameID,
 					players[1].PublicID,
@@ -1620,10 +1621,10 @@ var _ = Describe("Membership Model", func() {
 
 			It("If player reached the game's MaxClansPerPlayer", func() {
 				action := "approve"
-				game, _, owner, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, _, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				anotherClan := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				anotherClan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":   owner.GameID,
 					"PublicID": uuid.NewV4().String(),
 					"OwnerID":  owner.ID,
@@ -1632,7 +1633,7 @@ var _ = Describe("Membership Model", func() {
 				err = testDb.Insert(anotherClan)
 				Expect(err).NotTo(HaveOccurred())
 
-				membership := MembershipFactory.MustCreateWithOption(map[string]interface{}{
+				membership := fixtures.MembershipFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":      game.PublicID,
 					"PlayerID":    players[0].ID,
 					"ClanID":      anotherClan.ID,
@@ -1645,7 +1646,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1659,7 +1660,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Player is the membership requestor", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = players[0].ID
@@ -1668,7 +1669,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1682,10 +1683,10 @@ var _ = Describe("Membership Model", func() {
 
 			It("Membership does not exist", func() {
 				action := "approve"
-				game, clan, _, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -1693,7 +1694,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					player.GameID,
 					player.PublicID,
@@ -1707,7 +1708,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Membership is deleted", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].DeletedAt = util.NowMilli()
@@ -1717,7 +1718,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1731,7 +1732,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Membership is already approved", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -1740,7 +1741,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1754,7 +1755,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Membership is already denied", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Denied = true
@@ -1763,7 +1764,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1779,12 +1780,12 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should deny a Membership invitation with ApproveOrDenyMembershipInvitation if", func() {
 			It("Player is not the membership requestor", func() {
 				action := "deny"
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				updatedMembership, err := ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1809,12 +1810,12 @@ var _ = Describe("Membership Model", func() {
 
 		Describe("Should not ApproveOrDenyMembershipInvitation if", func() {
 			It("Invalid action", func() {
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = ApproveOrDenyMembershipInvitation(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1830,7 +1831,7 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should approve a Membership application with ApproveOrDenyMembershipApplication if", func() {
 			It("Owner", func() {
 				action := "approve"
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
@@ -1838,7 +1839,7 @@ var _ = Describe("Membership Model", func() {
 
 				updatedMembership, err := ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1859,7 +1860,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.ApproverID.Valid).To(BeTrue())
 				Expect(dbMembership.ApproverID.Int64).To(Equal(int64(owner.ID)))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), players[0].ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), players[0].ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -1870,7 +1871,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Requestor is member of the clan with level > minLevel", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 1, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Level = "CoLeader"
@@ -1883,7 +1884,7 @@ var _ = Describe("Membership Model", func() {
 
 				updatedMembership, err := ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[1].GameID,
 					players[1].PublicID,
@@ -1905,7 +1906,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Approved).To(Equal(true))
 				Expect(dbMembership.Denied).To(Equal(false))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), players[1].ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), players[1].ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(1))
 
@@ -1918,7 +1919,7 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should not approve a Membership application with ApproveOrDenyMembershipApplication if", func() {
 			It("If clan reached the game's MaxMembers", func() {
 				action := "approve"
-				game, clan, owner, players, memberships, err := GetClanReachedMaxMemberships(testDb)
+				game, clan, owner, players, memberships, err := fixtures.GetClanReachedMaxMemberships(testDb)
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[1].RequestorID = memberships[1].PlayerID
@@ -1927,7 +1928,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[1].GameID,
 					players[1].PublicID,
@@ -1942,10 +1943,10 @@ var _ = Describe("Membership Model", func() {
 
 			It("If player reached the game's MaxClansPerPlayer", func() {
 				action := "approve"
-				game, _, owner, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, _, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				anotherClan := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				anotherClan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":   owner.GameID,
 					"PublicID": uuid.NewV4().String(),
 					"OwnerID":  owner.ID,
@@ -1954,7 +1955,7 @@ var _ = Describe("Membership Model", func() {
 				err = testDb.Insert(anotherClan)
 				Expect(err).NotTo(HaveOccurred())
 
-				membership := MembershipFactory.MustCreateWithOption(map[string]interface{}{
+				membership := fixtures.MembershipFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":      game.PublicID,
 					"PlayerID":    players[0].ID,
 					"ClanID":      anotherClan.ID,
@@ -1967,7 +1968,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -1982,7 +1983,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Requestor is member of the clan with level < minLevel", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
@@ -1996,7 +1997,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -2011,7 +2012,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Requestor is not approved member of the clan", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
@@ -2025,7 +2026,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -2040,14 +2041,14 @@ var _ = Describe("Membership Model", func() {
 
 			It("Requestor is not member of the clan", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
 				_, err = testDb.Update(memberships[0])
 				Expect(err).NotTo(HaveOccurred())
 
-				requestor := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				requestor := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(requestor)
@@ -2055,7 +2056,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2070,7 +2071,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Requestor membership is deleted", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
@@ -2084,7 +2085,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2099,7 +2100,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Requestor is the player of the membership", func() {
 				action := "approve"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
@@ -2108,7 +2109,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2123,12 +2124,12 @@ var _ = Describe("Membership Model", func() {
 
 			It("Player was not the membership requestor", func() {
 				action := "approve"
-				game, clan, owner, players, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2143,10 +2144,10 @@ var _ = Describe("Membership Model", func() {
 
 			It("Membership does not exist", func() {
 				action := "approve"
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -2154,7 +2155,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					clan.GameID,
 					player.PublicID,
@@ -2169,7 +2170,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Membership is already approved", func() {
 				action := "approve"
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
@@ -2179,7 +2180,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2194,7 +2195,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Membership is already denied", func() {
 				action := "approve"
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
@@ -2204,7 +2205,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					clan.GameID,
 					players[0].PublicID,
@@ -2221,7 +2222,7 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should deny a Membership application with ApproveOrDenyMembershipApplication if", func() {
 			It("Owner", func() {
 				action := "deny"
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
@@ -2230,7 +2231,7 @@ var _ = Describe("Membership Model", func() {
 
 				updatedMembership, err := ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -2256,7 +2257,7 @@ var _ = Describe("Membership Model", func() {
 
 		Describe("Should not ApproveOrDenyMembershipApplication if", func() {
 			It("Invalid action", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].RequestorID = memberships[0].PlayerID
@@ -2265,7 +2266,7 @@ var _ = Describe("Membership Model", func() {
 
 				_, err = ApproveOrDenyMembershipApplication(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game,
 					players[0].GameID,
 					players[0].PublicID,
@@ -2282,7 +2283,7 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should promote a member with PromoteOrDemoteMember", func() {
 			It("If requestor is the owner", func() {
 				action := "promote"
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2310,7 +2311,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("If requestor has enough level", func() {
 				action := "promote"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2345,7 +2346,7 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should not promote a member with PromoteOrDemoteMember", func() {
 			It("If requestor is the player", func() {
 				action := "promote"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2368,7 +2369,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("If requestor does not have enough level", func() {
 				action := "promote"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2396,7 +2397,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("If requestor is not a clan member", func() {
 				action := "promote"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2420,7 +2421,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Requestor membership is deleted", func() {
 				action := "promote"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2447,10 +2448,10 @@ var _ = Describe("Membership Model", func() {
 
 			It("If player is not a clan member", func() {
 				action := "promote"
-				game, clan, owner, _, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				player := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				player := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(player)
@@ -2472,7 +2473,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("If player membership is not approved", func() {
 				action := "promote"
-				game, clan, owner, players, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = PromoteOrDemoteMember(
@@ -2491,7 +2492,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("If player membership is denied", func() {
 				action := "promote"
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Denied = true
@@ -2514,7 +2515,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("If requestor membership is not approved", func() {
 				action := "promote"
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2536,7 +2537,7 @@ var _ = Describe("Membership Model", func() {
 
 			It("Player is already max level", func() {
 				action := "promote"
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2562,7 +2563,7 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should demote a member with PromoteOrDemoteMember", func() {
 			It("If requestor is the owner", func() {
 				action := "demote"
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Level = "CoLeader"
@@ -2592,7 +2593,7 @@ var _ = Describe("Membership Model", func() {
 		Describe("Should not demote a member with PromoteOrDemoteMember if", func() {
 			It("Player is already min level", func() {
 				action := "demote"
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2617,7 +2618,7 @@ var _ = Describe("Membership Model", func() {
 
 		Describe("Should not PromoteOrDemoteMember", func() {
 			It("Invalid action", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[0].Approved = true
@@ -2641,7 +2642,7 @@ var _ = Describe("Membership Model", func() {
 
 		Describe("Should delete a membership with DeleteMembership", func() {
 			It("If requestor is the owner", func() {
-				game, clan, owner, players, memberships, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, clan, owner, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = DeleteMembership(
@@ -2662,7 +2663,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), memberships[0].PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), memberships[0].PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -2672,7 +2673,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor is the player", func() {
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = DeleteMembership(
@@ -2693,7 +2694,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), memberships[0].PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), memberships[0].PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -2703,7 +2704,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor has enough level and offset", func() {
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 2, 0, 0, 0, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 2, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[1].Level = "CoLeader"
@@ -2727,7 +2728,7 @@ var _ = Describe("Membership Model", func() {
 				Expect(dbMembership.Denied).To(Equal(false))
 				Expect(dbMembership.DeletedAt).To(BeNumerically(">", util.NowMilli()-1000))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), memberships[0].PlayerID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), memberships[0].PlayerID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(0))
 
@@ -2739,7 +2740,7 @@ var _ = Describe("Membership Model", func() {
 
 		Describe("Should not delete a membership with DeleteMembership", func() {
 			It("If requestor does not have enough level", func() {
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[1].Level = "Member"
@@ -2760,7 +2761,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor has enough level but not enough offset", func() {
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = DeleteMembership(
@@ -2776,10 +2777,10 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor is not a clan member", func() {
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 1, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
-				requestor := PlayerFactory.MustCreateWithOption(map[string]interface{}{
+				requestor := fixtures.PlayerFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID": clan.GameID,
 				}).(*Player)
 				err = testDb.Insert(requestor)
@@ -2799,7 +2800,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor membership is denied", func() {
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[1].Level = "CoLeader"
@@ -2820,7 +2821,7 @@ var _ = Describe("Membership Model", func() {
 			})
 
 			It("If requestor membership is not approved", func() {
-				game, clan, _, players, memberships, err := GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
+				game, clan, _, players, memberships, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 2, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				memberships[1].Level = "CoLeader"

--- a/models/mongo_worker.go
+++ b/models/mongo_worker.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/jrallison/go-workers"
@@ -50,6 +52,22 @@ func (w *MongoWorker) PerformUpdateMongo(m *workers.Msg) {
 	clanID := data["clanID"].(string)
 
 	w.updateClanIntoMongoDB(ctx, game, op, clan, clanID)
+}
+
+// InsertGame creates a game inside Mongo
+func (w *MongoWorker) InsertGame(ctx context.Context, gameID string, clan *Clan) error {
+	clanWithNamePrefixes := clan.NewClanWithNamePrefixes()
+	clanJSON, err := json.Marshal(clanWithNamePrefixes)
+	if err != nil {
+		return errors.New("Could not serialize clan")
+	}
+
+	var clanMap map[string]interface{}
+	json.Unmarshal(clanJSON, &clanMap)
+
+	w.updateClanIntoMongoDB(ctx, gameID, "update", clanMap, clan.PublicID)
+
+	return nil
 }
 
 func (w *MongoWorker) updateClanIntoMongoDB(

--- a/models/player_test.go
+++ b/models/player_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	egorp "github.com/topfreegames/extensions/v9/gorp/interfaces"
 	. "github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	"github.com/topfreegames/khan/testing"
 	"github.com/topfreegames/khan/util"
 	"github.com/uber-go/zap"
@@ -36,7 +37,7 @@ var _ = Describe("Player Model", func() {
 		Describe("Model Basic Tests", func() {
 			It("Should set CreatedAt and UpdatedAt as same value on creating a new player", func() {
 				gameID := uuid.NewV4().String()
-				game := GameFactory.MustCreateWithOption(map[string]interface{}{
+				game := fixtures.GameFactory.MustCreateWithOption(map[string]interface{}{
 					"PublicID": gameID,
 				}).(*Game)
 				err := testDb.Insert(game)
@@ -55,7 +56,7 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should update a new Player", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 				dt := player.UpdatedAt
 
@@ -71,27 +72,27 @@ var _ = Describe("Player Model", func() {
 
 		Describe("Get Player By ID", func() {
 			It("Should get existing Player", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.ID).To(Equal(player.ID))
 				Expect(dbPlayer.Name).To(Equal(player.Name))
 			})
 
 			It("Should not get non-existing Player", func() {
-				_, err := GetPlayerByID(testDb, GetEncryptionKey(), -1)
+				_, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), -1)
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Player was not found with id: -1"))
 			})
 
 			It("Should decrypt Player.Name", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				encryptedName, err := util.EncryptData(player.Name, GetEncryptionKey())
+				encryptedName, err := util.EncryptData(player.Name, fixtures.GetEncryptionKey())
 				Expect(err).NotTo(HaveOccurred())
 
 				name := player.Name
@@ -100,7 +101,7 @@ var _ = Describe("Player Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(int(count)).To(Equal(1))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.ID).To(Equal(player.ID))
 				Expect(dbPlayer.Name).To(Equal(name))
@@ -109,25 +110,25 @@ var _ = Describe("Player Model", func() {
 
 		Describe("Get Player By Public ID", func() {
 			It("Should get existing Player by Game and Player", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				dbPlayer, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), player.GameID, player.PublicID)
+				dbPlayer, err := GetPlayerByPublicID(testDb, fixtures.GetEncryptionKey(), player.GameID, player.PublicID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.ID).To(Equal(player.ID))
 			})
 
 			It("Should not get non-existing Player by Game and Player", func() {
-				_, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), "invalid-game", "invalid-player")
+				_, err := GetPlayerByPublicID(testDb, fixtures.GetEncryptionKey(), "invalid-game", "invalid-player")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Player was not found with id: invalid-player"))
 			})
 
 			It("Should decrypt Player.Name", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				encryptedName, err := util.EncryptData(player.Name, GetEncryptionKey())
+				encryptedName, err := util.EncryptData(player.Name, fixtures.GetEncryptionKey())
 				Expect(err).NotTo(HaveOccurred())
 
 				name := player.Name
@@ -136,7 +137,7 @@ var _ = Describe("Player Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(int(count)).To(Equal(1))
 
-				dbPlayer, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), player.GameID, player.PublicID)
+				dbPlayer, err := GetPlayerByPublicID(testDb, fixtures.GetEncryptionKey(), player.GameID, player.PublicID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.ID).To(Equal(player.ID))
 				Expect(dbPlayer.Name).To(Equal(name))
@@ -145,7 +146,7 @@ var _ = Describe("Player Model", func() {
 
 		Describe("Create Player", func() {
 			It("Should create a new Player with CreatePlayer", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -153,7 +154,7 @@ var _ = Describe("Player Model", func() {
 				player, err := CreatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game.PublicID,
 					playerID,
 					"player-name",
@@ -162,7 +163,7 @@ var _ = Describe("Player Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(player.ID).NotTo(BeEquivalentTo(0))
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(dbPlayer.GameID).To(Equal(player.GameID))
@@ -170,7 +171,7 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should create a new Player encrypting the Player.Name", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -179,7 +180,7 @@ var _ = Describe("Player Model", func() {
 				player, err := CreatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game.PublicID,
 					playerPublicID,
 					playerName,
@@ -194,14 +195,14 @@ var _ = Describe("Player Model", func() {
 
 				Expect(dbPlayer.Name).NotTo(Equal(playerName))
 
-				decryptedName, err := util.DecryptData(dbPlayer.Name, GetEncryptionKey())
+				decryptedName, err := util.DecryptData(dbPlayer.Name, fixtures.GetEncryptionKey())
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(decryptedName).To(Equal(player.Name))
 			})
 
 			It("Should create a EncryptedPlayer to trace players encryption process", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -210,7 +211,7 @@ var _ = Describe("Player Model", func() {
 				player, err := CreatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game.PublicID,
 					playerPublicID,
 					playerName,
@@ -228,14 +229,14 @@ var _ = Describe("Player Model", func() {
 
 		Describe("Update Player", func() {
 			It("Should update a Player with UpdatePlayer", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				metadata := map[string]interface{}{"x": "a"}
 				updatedPlayer, err := UpdatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					player.GameID,
 					player.PublicID,
 					player.Name,
@@ -245,14 +246,14 @@ var _ = Describe("Player Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updatedPlayer.ID).To(Equal(player.ID))
 
-				dbPlayer, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), player.GameID, player.PublicID)
+				dbPlayer, err := GetPlayerByPublicID(testDb, fixtures.GetEncryptionKey(), player.GameID, player.PublicID)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(dbPlayer.Metadata["x"]).To(BeEquivalentTo(metadata["x"]))
 			})
 
 			It("Should update a Player encrypting the Player.Name", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				playerName := uuid.NewV4().String()
@@ -260,7 +261,7 @@ var _ = Describe("Player Model", func() {
 				updatedPlayer, err := UpdatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					player.GameID,
 					player.PublicID,
 					playerName,
@@ -275,7 +276,7 @@ var _ = Describe("Player Model", func() {
 
 				Expect(dbPlayer.Name).NotTo(Equal(updatedPlayer.Name))
 
-				decryptedPlayerName, err := util.DecryptData(dbPlayer.Name, GetEncryptionKey())
+				decryptedPlayerName, err := util.DecryptData(dbPlayer.Name, fixtures.GetEncryptionKey())
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(decryptedPlayerName).To(Equal(playerName))
@@ -283,7 +284,7 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should create a EncryptedPlayer to trace players encryption process when updating a player", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				playerName := uuid.NewV4().String()
@@ -291,7 +292,7 @@ var _ = Describe("Player Model", func() {
 				_, err = UpdatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					player.GameID,
 					player.PublicID,
 					playerName,
@@ -307,7 +308,7 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should create Player with UpdatePlayer if player does not exist", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -318,7 +319,7 @@ var _ = Describe("Player Model", func() {
 				updPlayer, err := UpdatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					gameID,
 					publicID,
 					publicID,
@@ -328,14 +329,14 @@ var _ = Describe("Player Model", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updPlayer.ID).To(BeNumerically(">", 0))
 
-				dbPlayer, err := GetPlayerByPublicID(testDb, GetEncryptionKey(), updPlayer.GameID, updPlayer.PublicID)
+				dbPlayer, err := GetPlayerByPublicID(testDb, fixtures.GetEncryptionKey(), updPlayer.GameID, updPlayer.PublicID)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(dbPlayer.Metadata).To(Equal(metadata))
 			})
 
 			It("Should create Player with UpdatePlayer if player does not exist and encrypt player.Name", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -347,7 +348,7 @@ var _ = Describe("Player Model", func() {
 				createdPlayer, err := UpdatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					gameID,
 					publicID,
 					playerName,
@@ -364,14 +365,14 @@ var _ = Describe("Player Model", func() {
 
 				Expect(dbPlayer.Name).NotTo(Equal(createdPlayer.Name))
 
-				decryptedPlayerName, err := util.DecryptData(dbPlayer.Name, GetEncryptionKey())
+				decryptedPlayerName, err := util.DecryptData(dbPlayer.Name, fixtures.GetEncryptionKey())
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(decryptedPlayerName).To(Equal(playerName))
 			})
 
 			It("Should create a EncryptedPlayer to trace players encryption process when creating a player", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -381,7 +382,7 @@ var _ = Describe("Player Model", func() {
 				player, err := UpdatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game.PublicID,
 					playerPublicID,
 					playerName,
@@ -397,7 +398,7 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should return player normally if EncryptedPlayer is already created", func() {
-				game := GameFactory.MustCreate().(*Game)
+				game := fixtures.GameFactory.MustCreate().(*Game)
 				err := testDb.Insert(game)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -405,7 +406,7 @@ var _ = Describe("Player Model", func() {
 				_, err = CreatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game.PublicID,
 					uuid.NewV4().String(),
 					uuid.NewV4().String(),
@@ -416,7 +417,7 @@ var _ = Describe("Player Model", func() {
 				player, err := UpdatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game.PublicID,
 					uuid.NewV4().String(),
 					uuid.NewV4().String(),
@@ -435,7 +436,7 @@ var _ = Describe("Player Model", func() {
 				_, err := UpdatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					"-1",
 					"qwe",
 					"some player name",
@@ -449,12 +450,12 @@ var _ = Describe("Player Model", func() {
 		Describe("Get Player Details", func() {
 			It("Should get Player Details", func() {
 				gameID := uuid.NewV4().String()
-				_, player, err := GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
+				_, player, err := fixtures.GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
 				Expect(err).NotTo(HaveOccurred())
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					player.GameID,
 					player.PublicID,
 				)
@@ -521,7 +522,7 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should get Player Details without memberships that were deleted by the player", func() {
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = DeleteMembership(
@@ -536,7 +537,7 @@ var _ = Describe("Player Model", func() {
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					players[0].GameID,
 					players[0].PublicID,
 				)
@@ -568,7 +569,7 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should get owned clans as not deleted if there are deleted memberships of other clans (a.k.a fix John's bug)", func() {
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = DeleteMembership(
@@ -583,7 +584,7 @@ var _ = Describe("Player Model", func() {
 
 				c, err := CreateClan(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game.PublicID,
 					"johns-bug-clan",
 					"johns-bug-clan",
@@ -598,7 +599,7 @@ var _ = Describe("Player Model", func() {
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					players[0].GameID,
 					players[0].PublicID,
 				)
@@ -632,14 +633,14 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should get Player Details including owned clans", func() {
-				game, clan, _, players, _, err := GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
+				game, clan, _, players, _, err := fixtures.GetClanWithMemberships(testDb, 1, 0, 0, 0, "", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				game.MaxClansPerPlayer = 2
 				_, err = testDb.Update(game)
 				Expect(err).NotTo(HaveOccurred())
 
-				ownedClan := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				ownedClan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":          players[0].GameID,
 					"PublicID":        uuid.NewV4().String(),
 					"OwnerID":         players[0].ID,
@@ -651,7 +652,7 @@ var _ = Describe("Player Model", func() {
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					players[0].GameID,
 					players[0].PublicID,
 				)
@@ -698,12 +699,12 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should get Player Details when player has no affiliations", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					player.GameID,
 					player.PublicID,
 				)
@@ -736,22 +737,22 @@ var _ = Describe("Player Model", func() {
 
 			It("Should decrypt Player.Name in Details", func() {
 				gameID := uuid.NewV4().String()
-				owner, player, err := GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
+				owner, player, err := fixtures.GetTestPlayerWithMemberships(testDb, gameID, 5, 2, 3, 8)
 				Expect(err).NotTo(HaveOccurred())
 
-				testing.UpdateEncryptingTestPlayer(testDb, GetEncryptionKey(), owner)
-				testing.UpdateEncryptingTestPlayer(testDb, GetEncryptionKey(), player)
+				testing.UpdateEncryptingTestPlayer(testDb, fixtures.GetEncryptionKey(), owner)
+				testing.UpdateEncryptingTestPlayer(testDb, fixtures.GetEncryptionKey(), player)
 
 				playerDetails, err := GetPlayerDetails(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					player.GameID,
 					player.PublicID,
 				)
 
 				Expect(err).NotTo(HaveOccurred())
 
-				testing.DecryptTestPlayer(GetEncryptionKey(), player)
+				testing.DecryptTestPlayer(fixtures.GetEncryptionKey(), player)
 
 				Expect(playerDetails["name"]).To(Equal(player.Name))
 
@@ -766,7 +767,7 @@ var _ = Describe("Player Model", func() {
 				denier := deniedMembership["denier"].(map[string]interface{})
 				Expect(denier["name"]).To(Equal(player.Name))
 
-				testing.DecryptTestPlayer(GetEncryptionKey(), owner)
+				testing.DecryptTestPlayer(fixtures.GetEncryptionKey(), owner)
 
 				pendingInvite := playerDetails["memberships"].([]map[string]interface{})[14]
 				Expect(pendingInvite["requestor"]).NotTo(BeEquivalentTo(nil))
@@ -777,7 +778,7 @@ var _ = Describe("Player Model", func() {
 			It("Should return error if Player does not exist", func() {
 				playerDetails, err := GetPlayerDetails(
 					testDb,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					"game-id",
 					"invalid-player-id",
 				)
@@ -791,10 +792,10 @@ var _ = Describe("Player Model", func() {
 		Describe("Update Player Membership Count", func() {
 			It("Should work if membership is created", func() {
 				prevMemberships := 5
-				_, player, err := GetTestPlayerWithMemberships(testDb, "", prevMemberships, 2, 3, 4)
+				_, player, err := fixtures.GetTestPlayerWithMemberships(testDb, "", prevMemberships, 2, 3, 4)
 				Expect(err).NotTo(HaveOccurred())
 
-				clan := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				clan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":          player.GameID,
 					"PublicID":        uuid.NewV4().String(),
 					"OwnerID":         player.ID,
@@ -804,7 +805,7 @@ var _ = Describe("Player Model", func() {
 				err = testDb.Insert(clan)
 				Expect(err).NotTo(HaveOccurred())
 
-				membership := MembershipFactory.MustCreateWithOption(map[string]interface{}{
+				membership := fixtures.MembershipFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":      player.GameID,
 					"PlayerID":    player.ID,
 					"ClanID":      clan.ID,
@@ -820,14 +821,14 @@ var _ = Describe("Player Model", func() {
 				err = UpdatePlayerMembershipCount(testDb, player.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(prevMemberships + 1))
 			})
 
 			It("Should work if membership is deleted", func() {
 				prevMemberships := 5
-				_, player, err := GetTestPlayerWithMemberships(testDb, "", prevMemberships, 2, 3, 4)
+				_, player, err := fixtures.GetTestPlayerWithMemberships(testDb, "", prevMemberships, 2, 3, 4)
 				Expect(err).NotTo(HaveOccurred())
 
 				var membership *Membership
@@ -840,7 +841,7 @@ var _ = Describe("Player Model", func() {
 				err = UpdatePlayerMembershipCount(testDb, player.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.MembershipCount).To(Equal(prevMemberships - 1))
 			})
@@ -854,13 +855,13 @@ var _ = Describe("Player Model", func() {
 
 		Describe("Update Player Ownership Count", func() {
 			It("Should work if clan is created", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 				player.OwnershipCount = 123 // some random value
 				_, err = testDb.Update(player)
 				Expect(err).NotTo(HaveOccurred())
 
-				clan := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				clan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":          player.GameID,
 					"PublicID":        uuid.NewV4().String(),
 					"OwnerID":         player.ID,
@@ -872,16 +873,16 @@ var _ = Describe("Player Model", func() {
 
 				err = UpdatePlayerOwnershipCount(testDb, player.ID)
 				Expect(err).NotTo(HaveOccurred())
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.OwnershipCount).To(Equal(1))
 			})
 
 			It("Should work if clan is deleted", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				clan := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				clan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":          player.GameID,
 					"PublicID":        uuid.NewV4().String(),
 					"OwnerID":         player.ID,
@@ -894,7 +895,7 @@ var _ = Describe("Player Model", func() {
 				err = UpdatePlayerOwnershipCount(testDb, player.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				clanToBeDeleted := ClanFactory.MustCreateWithOption(map[string]interface{}{
+				clanToBeDeleted := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
 					"GameID":          player.GameID,
 					"PublicID":        uuid.NewV4().String(),
 					"OwnerID":         player.ID,
@@ -908,7 +909,7 @@ var _ = Describe("Player Model", func() {
 
 				err = UpdatePlayerOwnershipCount(testDb, player.ID)
 				Expect(err).NotTo(HaveOccurred())
-				dbPlayer, err := GetPlayerByID(testDb, GetEncryptionKey(), player.ID)
+				dbPlayer, err := GetPlayerByID(testDb, fixtures.GetEncryptionKey(), player.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dbPlayer.OwnershipCount).To(Equal(1))
 			})
@@ -934,17 +935,17 @@ var _ = Describe("Player Model", func() {
 
 			It("Should return a slice of players that has no EncryptedPlayer", func() {
 				gameID := uuid.NewV4().String()
-				game := GameFactory.MustCreateWithOption(map[string]interface{}{
+				game := fixtures.GameFactory.MustCreateWithOption(map[string]interface{}{
 					"PublicID": gameID,
 				}).(*Game)
 
-				_, player, err := CreatePlayerFactory(testDb, gameID)
+				_, player, err := fixtures.CreatePlayerFactory(testDb, gameID)
 				Expect(err).NotTo(HaveOccurred())
 
 				encryptedPlayer, err := CreatePlayer(
 					testDb,
 					logger,
-					GetEncryptionKey(),
+					fixtures.GetEncryptionKey(),
 					game.PublicID,
 					uuid.NewV4().String(),
 					"player-name",
@@ -952,7 +953,7 @@ var _ = Describe("Player Model", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				playersToEncrypt, err := GetPlayersToEncrypt(testDb, GetEncryptionKey(), 10)
+				playersToEncrypt, err := GetPlayersToEncrypt(testDb, fixtures.GetEncryptionKey(), 10)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(playersToEncrypt[0].Name).To(Equal(player.Name))
@@ -966,13 +967,13 @@ var _ = Describe("Player Model", func() {
 			})
 
 			It("Should return the amount of players", func() {
-				_, _, err := CreatePlayerFactory(testDb, "")
+				_, _, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				_, _, err = CreatePlayerFactory(testDb, "")
+				_, _, err = fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				playersToEncrypt, err := GetPlayersToEncrypt(testDb, GetEncryptionKey(), 1)
+				playersToEncrypt, err := GetPlayersToEncrypt(testDb, fixtures.GetEncryptionKey(), 1)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(len(playersToEncrypt)).To(Equal(1))
@@ -981,10 +982,10 @@ var _ = Describe("Player Model", func() {
 
 		Describe("ApplySecurityChanges", func() {
 			It("Should encrypt and update players", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				_, secondPlayer, err := CreatePlayerFactory(testDb, "")
+				_, secondPlayer, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				playerName := player.Name
@@ -992,7 +993,7 @@ var _ = Describe("Player Model", func() {
 
 				players := []*Player{player, secondPlayer}
 
-				err = ApplySecurityChanges(testDb, GetEncryptionKey(), players)
+				err = ApplySecurityChanges(testDb, fixtures.GetEncryptionKey(), players)
 				Expect(err).NotTo(HaveOccurred())
 
 				var recoveredPlayer, secondRecoveredPlayer *Player
@@ -1005,27 +1006,27 @@ var _ = Describe("Player Model", func() {
 				Expect(recoveredPlayer.ID).To(Equal(player.ID))
 				Expect(playerName).NotTo(Equal(player.Name))
 
-				decryptedPlayerName, err := util.DecryptData(recoveredPlayer.Name, GetEncryptionKey())
+				decryptedPlayerName, err := util.DecryptData(recoveredPlayer.Name, fixtures.GetEncryptionKey())
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(decryptedPlayerName).To(Equal(playerName))
 
-				decryptedPlayerName, err = util.DecryptData(secondRecoveredPlayer.Name, GetEncryptionKey())
+				decryptedPlayerName, err = util.DecryptData(secondRecoveredPlayer.Name, fixtures.GetEncryptionKey())
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(decryptedPlayerName).To(Equal(secondPlayerName))
 			})
 
 			It("Should create EncryptedPlayer to each player", func() {
-				_, player, err := CreatePlayerFactory(testDb, "")
+				_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
-				_, secondPlayer, err := CreatePlayerFactory(testDb, "")
+				_, secondPlayer, err := fixtures.CreatePlayerFactory(testDb, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				players := []*Player{player, secondPlayer}
 
-				err = ApplySecurityChanges(testDb, GetEncryptionKey(), players)
+				err = ApplySecurityChanges(testDb, fixtures.GetEncryptionKey(), players)
 				Expect(err).NotTo(HaveOccurred())
 
 				var encryptedPlayer *EncryptedPlayer

--- a/models/prune_test.go
+++ b/models/prune_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/models/fixtures"
 	"github.com/uber-go/zap"
 )
 
@@ -34,12 +35,12 @@ var _ = Describe("Prune Stale Data Model", func() {
 	Describe("Prune Stale Data Model", func() {
 		Describe("Pruning Stale data", func() {
 			It("Should remove pending applications", func() {
-				gameID, err := GetTestClanWithStaleData(testDb, 5, 6, 7, 8)
+				gameID, err := fixtures.GetTestClanWithStaleData(testDb, 5, 6, 7, 8)
 				Expect(err).NotTo(HaveOccurred())
 
 				expiration := int((2 * time.Hour).Seconds())
 				options := &PruneOptions{
-					GameID: gameID,
+					GameID:                        gameID,
 					PendingApplicationsExpiration: expiration,
 					PendingInvitesExpiration:      expiration,
 					DeniedMembershipsExpiration:   expiration,


### PR DESCRIPTION
We had fixed the flaky test by using a `time.Sleep`, but this is a very bad way of solving it.

This PR changes:
* extract fixtures from module `models`
* Rename `GetTestClans` to `CreateTestClans`
* Add a new argument to `CreateTestClans` to work as a _strategy_ , so we don't have a static behavior in the function.
* Replace `app.NonblockingStartWorkers()` usage for `fixtures.ConfigureAndStartGoWorkers()`