### PR TITLE
Create text index when a new game is created

### DIFF
--- a/api/clan_test.go
+++ b/api/clan_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should create clan into mongodb if its configured", func() {
-			mongo, err := GetTestMongo()
+			mongo, err := testing.GetTestMongo()
 			Expect(err).NotTo(HaveOccurred())
 			_, player, err := fixtures.CreatePlayerFactory(testDb, "")
 			Expect(err).NotTo(HaveOccurred())
@@ -361,7 +361,7 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should update Mongo if update clan", func() {
-			mongo, err := GetTestMongo()
+			mongo, err := testing.GetTestMongo()
 			Expect(err).NotTo(HaveOccurred())
 			_, clan, owner, _, _, err := fixtures.GetClanWithMemberships(testDb, 0, 0, 0, 0, "", "")
 			Expect(err).NotTo(HaveOccurred())
@@ -563,7 +563,10 @@ var _ = Describe("Clan API Handler", func() {
 
 	Describe("List All Clans Handler", func() {
 		It("Should get all clans", func() {
-			player, expectedClans, err := fixtures.CreateTestClans(testDb, "", "", 10, fixtures.EnqueueClanForMongoUpdate)
+			mongoDB, err := testing.GetTestMongo()
+			Expect(err).NotTo(HaveOccurred())
+
+			player, expectedClans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 10, fixtures.EnqueueClanForMongoUpdate)
 			Expect(err).NotTo(HaveOccurred())
 			sort.Sort(models.ClanByName(expectedClans))
 
@@ -1047,12 +1050,12 @@ var _ = Describe("Clan API Handler", func() {
 			}
 
 			gameID := uuid.NewV4().String()
-			player, expectedClans, err := fixtures.CreateTestClans(
-				testDb, gameID, "clan-apisearch-clan", 10, insertClanIntoMongo,
-			)
+			mongoDB, err := testing.GetTestMongo()
 			Expect(err).NotTo(HaveOccurred())
 
-			err = testing.CreateClanNameTextIndexInMongo(GetTestMongo, gameID)
+			player, expectedClans, err := fixtures.CreateTestClans(
+				testDb, mongoDB, gameID, "clan-apisearch-clan", 10, insertClanIntoMongo,
+			)
 			Expect(err).NotTo(HaveOccurred())
 
 			status, body := Get(app, GetGameRoute(player.GameID, "clans/search?term=APISEARCH"))
@@ -1082,9 +1085,12 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should search for a clan by publicID", func() {
+			mongoDB, err := testing.GetTestMongo()
+			Expect(err).NotTo(HaveOccurred())
+
 			gameID := uuid.NewV4().String()
 			player, expectedClans, err := fixtures.CreateTestClans(
-				testDb, gameID, "clan-apisearch-clan", 10, fixtures.EnqueueClanForMongoUpdate,
+				testDb, mongoDB, gameID, "clan-apisearch-clan", 10, fixtures.EnqueueClanForMongoUpdate,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			time.Sleep(1000 * time.Millisecond)
@@ -1106,13 +1112,13 @@ var _ = Describe("Clan API Handler", func() {
 		})
 
 		It("Should unicode search for a clan", func() {
-			gameID := uuid.NewV4().String()
-			player, expectedClans, err := fixtures.CreateTestClans(
-				testDb, gameID, "clan-apisearch-clan", 10, fixtures.EnqueueClanForMongoUpdate,
-			)
+			mongoDB, err := testing.GetTestMongo()
 			Expect(err).NotTo(HaveOccurred())
 
-			err = testing.CreateClanNameTextIndexInMongo(GetTestMongo, gameID)
+			gameID := uuid.NewV4().String()
+			player, expectedClans, err := fixtures.CreateTestClans(
+				testDb, mongoDB, gameID, "clan-apisearch-clan", 10, fixtures.EnqueueClanForMongoUpdate,
+			)
 			Expect(err).NotTo(HaveOccurred())
 
 			url := "clans/search?term=💩clán-clan-APISEARCH"

--- a/api/game.go
+++ b/api/game.go
@@ -90,9 +90,11 @@ func CreateGameHandler(app *App) func(c echo.Context) error {
 			return FailWith(500, err.Error(), c)
 		}
 
-		err = app.MongoDB.Run(mongo.GetClanNameTextIndexCommand(game.PublicID, false), nil)
-		if err != nil {
-			app.Rollback(tx, "Game", c, logger, err)
+		if app.MongoDB != nil {
+			err = app.MongoDB.Run(mongo.GetClanNameTextIndexCommand(game.PublicID, false), nil)
+			if err != nil {
+				app.Rollback(tx, "Game", c, logger, err)
+			}
 		}
 
 		txErr := app.Commit(tx, "Game", c, logger)

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -18,16 +18,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/viper"
 	"github.com/uber-go/zap"
 
 	"github.com/labstack/echo/engine/standard"
 	. "github.com/onsi/gomega"
-	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/api"
 	"github.com/topfreegames/khan/es"
 	"github.com/topfreegames/khan/models"
-	"github.com/topfreegames/khan/mongo"
 	kt "github.com/topfreegames/khan/testing"
 )
 
@@ -39,18 +36,6 @@ func GetTestES() *es.Client {
 	}
 	testES = es.GetTestClient("localhost", 9200, "", false, zap.New(zap.NewJSONEncoder(), zap.ErrorLevel), false)
 	return testES
-}
-
-func GetTestMongo() (interfaces.MongoDB, error) {
-	config := viper.New()
-	config.SetConfigType("yaml")
-	config.SetConfigFile("../config/test.yaml")
-	err := config.ReadInConfig()
-	if err != nil {
-		return nil, err
-	}
-	logger := kt.NewMockLogger()
-	return mongo.GetMongo(logger, config)
 }
 
 func DestroyTestES() {

--- a/bench/clan_test.go
+++ b/bench/clan_test.go
@@ -217,7 +217,7 @@ func BenchmarkSearchClan(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		route := getRoute(fmt.Sprintf("/games/%s/clans/search?term=%s", game.Name, clans[0].PublicID))
+		route := getRoute(fmt.Sprintf("/games/%s/clans/search?term=%s", game.PublicID, clans[0].PublicID))
 		res, err := get(route)
 		validateResp(res, err)
 		res.Body.Close()

--- a/bench/clan_test.go
+++ b/bench/clan_test.go
@@ -57,6 +57,8 @@ func BenchmarkCreateClan(b *testing.B) {
 }
 
 func BenchmarkUpdateClan(b *testing.B) {
+	fixtures.ConfigureAndStartGoWorkers()
+
 	db, err := models.GetPerfDB()
 	if err != nil {
 		panic(err.Error())
@@ -145,6 +147,8 @@ func BenchmarkRetrieveClanSummary(b *testing.B) {
 }
 
 func BenchmarkRetrieveClansSummary(b *testing.B) {
+	fixtures.ConfigureAndStartGoWorkers()
+
 	db, err := models.GetPerfDB()
 	if err != nil {
 		panic(err.Error())
@@ -183,6 +187,7 @@ func BenchmarkRetrieveClansSummary(b *testing.B) {
 }
 
 func BenchmarkSearchClan(b *testing.B) {
+	fixtures.ConfigureAndStartGoWorkers()
 	db, err := models.GetPerfDB()
 	if err != nil {
 		panic(err.Error())
@@ -216,6 +221,8 @@ func BenchmarkSearchClan(b *testing.B) {
 }
 
 func BenchmarkListClans(b *testing.B) {
+	fixtures.ConfigureAndStartGoWorkers()
+
 	db, err := models.GetPerfDB()
 	if err != nil {
 		panic(err.Error())
@@ -249,6 +256,8 @@ func BenchmarkListClans(b *testing.B) {
 }
 
 func BenchmarkLeaveClan(b *testing.B) {
+	fixtures.ConfigureAndStartGoWorkers()
+
 	db, err := models.GetPerfDB()
 	if err != nil {
 		panic(err.Error())

--- a/bench/clan_test.go
+++ b/bench/clan_test.go
@@ -16,7 +16,6 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/models/fixtures"
-	khanTesting "github.com/topfreegames/khan/testing"
 )
 
 var result *http.Response
@@ -189,11 +188,6 @@ func BenchmarkSearchClan(b *testing.B) {
 	}
 
 	b.ResetTimer()
-
-	err = khanTesting.CreateClanNameTextIndexInMongo(getTestMongo, game.Name)
-	if err != nil {
-		panic(err.Error())
-	}
 
 	for i := 0; i < b.N; i++ {
 		route := getRoute(fmt.Sprintf("/games/%s/clans/search?term=%s", game.Name, clans[0].PublicID))

--- a/bench/clan_test.go
+++ b/bench/clan_test.go
@@ -27,7 +27,12 @@ func BenchmarkCreateClan(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, _, err := getGameAndPlayer(db)
+	mongoDB, err := khanTesting.GetTestMongo()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	game, _, err := getGameAndPlayer(db, mongoDB)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -69,12 +74,12 @@ func BenchmarkUpdateClan(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, owner, err := getGameAndPlayer(db)
+	game, owner, err := getGameAndPlayer(db, mongoDB)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	clans, err := createClans(db, mongoDB, game, owner, b.N)
+	clans, err := createClans(db, game, owner, b.N)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -159,12 +164,12 @@ func BenchmarkRetrieveClansSummary(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, owner, err := getGameAndPlayer(db)
+	game, owner, err := getGameAndPlayer(db, mongoDB)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	clans, err := createClans(db, mongoDB, game, owner, 500)
+	clans, err := createClans(db, game, owner, 500)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -188,6 +193,7 @@ func BenchmarkRetrieveClansSummary(b *testing.B) {
 
 func BenchmarkSearchClan(b *testing.B) {
 	fixtures.ConfigureAndStartGoWorkers()
+
 	db, err := models.GetPerfDB()
 	if err != nil {
 		panic(err.Error())
@@ -198,12 +204,12 @@ func BenchmarkSearchClan(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, owner, err := getGameAndPlayer(db)
+	game, owner, err := getGameAndPlayer(db, mongoDB)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	clans, err := createClans(db, mongoDB, game, owner, b.N)
+	clans, err := createClans(db, game, owner, b.N)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -233,12 +239,12 @@ func BenchmarkListClans(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, owner, err := getGameAndPlayer(db)
+	game, owner, err := getGameAndPlayer(db, mongoDB)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	_, err = createClans(db, mongoDB, game, owner, b.N)
+	_, err = createClans(db, game, owner, b.N)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -268,12 +274,12 @@ func BenchmarkLeaveClan(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, owner, err := getGameAndPlayer(db)
+	game, owner, err := getGameAndPlayer(db, mongoDB)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	clans, err := createClans(db, mongoDB, game, owner, b.N)
+	clans, err := createClans(db, game, owner, b.N)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/bench/clan_test.go
+++ b/bench/clan_test.go
@@ -16,6 +16,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/models/fixtures"
+	khanTesting "github.com/topfreegames/khan/testing"
 )
 
 var result *http.Response
@@ -61,12 +62,17 @@ func BenchmarkUpdateClan(b *testing.B) {
 		panic(err.Error())
 	}
 
+	mongoDB, err := khanTesting.GetTestMongo()
+	if err != nil {
+		panic(err.Error())
+	}
+
 	game, owner, err := getGameAndPlayer(db)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	clans, err := createClans(db, game, owner, b.N)
+	clans, err := createClans(db, mongoDB, game, owner, b.N)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -144,12 +150,17 @@ func BenchmarkRetrieveClansSummary(b *testing.B) {
 		panic(err.Error())
 	}
 
+	mongoDB, err := khanTesting.GetTestMongo()
+	if err != nil {
+		panic(err.Error())
+	}
+
 	game, owner, err := getGameAndPlayer(db)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	clans, err := createClans(db, game, owner, 500)
+	clans, err := createClans(db, mongoDB, game, owner, 500)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -177,12 +188,17 @@ func BenchmarkSearchClan(b *testing.B) {
 		panic(err.Error())
 	}
 
+	mongoDB, err := khanTesting.GetTestMongo()
+	if err != nil {
+		panic(err.Error())
+	}
+
 	game, owner, err := getGameAndPlayer(db)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	clans, err := createClans(db, game, owner, b.N)
+	clans, err := createClans(db, mongoDB, game, owner, b.N)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -205,12 +221,17 @@ func BenchmarkListClans(b *testing.B) {
 		panic(err.Error())
 	}
 
+	mongoDB, err := khanTesting.GetTestMongo()
+	if err != nil {
+		panic(err.Error())
+	}
+
 	game, owner, err := getGameAndPlayer(db)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	_, err = createClans(db, game, owner, b.N)
+	_, err = createClans(db, mongoDB, game, owner, b.N)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -233,12 +254,17 @@ func BenchmarkLeaveClan(b *testing.B) {
 		panic(err.Error())
 	}
 
+	mongoDB, err := khanTesting.GetTestMongo()
+	if err != nil {
+		panic(err.Error())
+	}
+
 	game, owner, err := getGameAndPlayer(db)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	clans, err := createClans(db, game, owner, b.N)
+	clans, err := createClans(db, mongoDB, game, owner, b.N)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/bench/helpers.go
+++ b/bench/helpers.go
@@ -105,7 +105,7 @@ func getGameAndPlayer(db models.DB, mongoDB interfaces.MongoDB) (*models.Game, *
 		return nil, nil, err
 	}
 
-	err := mongoDB.Run(mongo.GetClanNameTextIndexCommand(game.PublicID, false), nil)
+	err = mongoDB.Run(mongo.GetClanNameTextIndexCommand(game.PublicID, false), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/bench/helpers.go
+++ b/bench/helpers.go
@@ -15,24 +15,9 @@ import (
 	"net/http"
 
 	uuid "github.com/satori/go.uuid"
-	"github.com/spf13/viper"
-	"github.com/topfreegames/extensions/v9/mongo"
-	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/models/fixtures"
 )
-
-func getTestMongo() (interfaces.MongoDB, error) {
-	config := viper.New()
-	config.SetConfigType("yaml")
-	config.SetConfigFile("../config/perf.yaml")
-	err := config.ReadInConfig()
-	if err != nil {
-		return nil, err
-	}
-	client, err := mongo.NewClient("mongodb", config)
-	return client.MongoDB, err
-}
 
 func getRoute(url string) string {
 	return fmt.Sprintf("http://localhost:8888%s", url)

--- a/bench/helpers.go
+++ b/bench/helpers.go
@@ -15,8 +15,10 @@ import (
 	"net/http"
 
 	uuid "github.com/satori/go.uuid"
+	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/models/fixtures"
+	"github.com/topfreegames/khan/mongo"
 )
 
 func getRoute(url string) string {
@@ -117,7 +119,7 @@ func validateResp(res *http.Response, err error) {
 	}
 }
 
-func createClans(db models.DB, game *models.Game, owner *models.Player, numberOfClans int) ([]*models.Clan, error) {
+func createClans(db models.DB, mongoDB interfaces.MongoDB, game *models.Game, owner *models.Player, numberOfClans int) ([]*models.Clan, error) {
 	var clans []*models.Clan
 	for i := 0; i < numberOfClans; i++ {
 		clan := fixtures.ClanFactory.MustCreateWithOption(map[string]interface{}{
@@ -131,6 +133,11 @@ func createClans(db models.DB, game *models.Game, owner *models.Player, numberOf
 			return nil, err
 		}
 		clans = append(clans, clan)
+	}
+
+	err := mongoDB.Run(mongo.GetClanNameTextIndexCommand(game.PublicID, false), nil)
+	if err != nil {
+		return nil, err
 	}
 
 	return clans, nil

--- a/bench/player_test.go
+++ b/bench/player_test.go
@@ -15,6 +15,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/topfreegames/khan/models"
 	"github.com/topfreegames/khan/models/fixtures"
+	khanTesting "github.com/topfreegames/khan/testing"
 )
 
 var playerResult *http.Response
@@ -25,7 +26,12 @@ func BenchmarkCreatePlayer(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, _, err := getGameAndPlayer(db)
+	mongoDB, err := khanTesting.GetTestMongo()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	game, _, err := getGameAndPlayer(db, mongoDB)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -48,7 +54,12 @@ func BenchmarkUpdatePlayer(b *testing.B) {
 		panic(err.Error())
 	}
 
-	game, _, err := getGameAndPlayer(db)
+	mongoDB, err := khanTesting.GetTestMongo()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	game, _, err := getGameAndPlayer(db, mongoDB)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/caches/clan_test.go
+++ b/caches/clan_test.go
@@ -18,6 +18,8 @@ var _ = Describe("Clan Cache", func() {
 		var err error
 		testDb, err = testing.GetTestDB()
 		Expect(err).NotTo(HaveOccurred())
+
+		fixtures.ConfigureAndStartGoWorkers()
 	})
 
 	Describe("Clans Summaries", func() {
@@ -76,8 +78,11 @@ var _ = Describe("Clan Cache", func() {
 		}
 
 		It("Should return a cached payload for a second call made immediately after the first", func() {
+			mongoDB, err := testing.GetTestMongo()
+			Expect(err).NotTo(HaveOccurred())
+
 			gameID := uuid.NewV4().String()
-			_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, fixtures.EnqueueClanForMongoUpdate)
+			_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, gameID, "test-sort-clan", 10, fixtures.EnqueueClanForMongoUpdate)
 			Expect(err).NotTo(HaveOccurred())
 
 			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)
@@ -99,8 +104,11 @@ var _ = Describe("Clan Cache", func() {
 		})
 
 		It("Should return fresh information after expiration time is reached", func() {
+			mongoDB, err := testing.GetTestMongo()
+			Expect(err).NotTo(HaveOccurred())
+
 			gameID := uuid.NewV4().String()
-			_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, fixtures.EnqueueClanForMongoUpdate)
+			_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, gameID, "test-sort-clan", 10, fixtures.EnqueueClanForMongoUpdate)
 			Expect(err).NotTo(HaveOccurred())
 
 			publicIDs, idToIdx := getPublicIDsAndIDToIndexMap(clans)

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,8 +1,9 @@
 postgres:
-  user: "khan"
+  user: "postgres"
   dbName: "khan"
+  password: "123456"
   host: "localhost"
-  port: 5433
+  port: 5432
   sslMode: "disable"
 
 elasticsearch:
@@ -13,7 +14,7 @@ elasticsearch:
   index: "khan"
 
 mongodb:
-  enabled: false
+  enabled: true
   url: mongodb://localhost:27017
   databaseName: "khan"
   collectionTemplate: "clans_%s"
@@ -38,7 +39,7 @@ jaeger:
 
 redis:
   host: 0.0.0.0
-  port: 50505
+  port: 6379
   database: 0
   pool: 30
   password: ""

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/topfreegames/extensions v8.5.0+incompatible
 	github.com/topfreegames/extensions/v9 v9.0.0
 	github.com/topfreegames/goose v0.0.0-20160616205307-c7f6dd34057c
 	github.com/uber-go/atomic v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,7 +129,6 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc=
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
-github.com/getsentry/raven-go v0.0.0-20170918144728-1452f6376ddb/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180615134936-113d3961e731 h1:y7wyeiA6T+TT+HGC9DYypvLkUeg99N4rqHMzn2MmjYk=
 github.com/globalsign/mgo v0.0.0-20180615134936-113d3961e731/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,7 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc=
 github.com/garyburd/redigo v1.6.0/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
+github.com/getsentry/raven-go v0.0.0-20170918144728-1452f6376ddb/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180615134936-113d3961e731 h1:y7wyeiA6T+TT+HGC9DYypvLkUeg99N4rqHMzn2MmjYk=
 github.com/globalsign/mgo v0.0.0-20180615134936-113d3961e731/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -422,6 +423,9 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/topfreegames/extensions v1.2.1 h1:a5VgxBnhg644GjnGFO2Rt0u3GaQJQwBqLzmwM5FttoE=
+github.com/topfreegames/extensions v8.5.0+incompatible h1:l3jQt6ufqC9BZzag/bCN69D9tkDJvSH/KdNGKSvkyQY=
+github.com/topfreegames/extensions v8.5.0+incompatible/go.mod h1:VbIAks7aNbkANieZyVShAV3FSxEbV6useS4r3neXVzc=
 github.com/topfreegames/extensions/v9 v9.0.0 h1:ggPkQ32VlwHnwcrUD7L0A9vc2eK4aXOOtaKmCjX+dz0=
 github.com/topfreegames/extensions/v9 v9.0.0/go.mod h1:QECdo96zIuSzv/duYMNZkChop/Z26ddVCD0vFZLY4LE=
 github.com/topfreegames/goose v0.0.0-20160616205307-c7f6dd34057c h1:fjBoT34+rt+Lbo3M70E1tgUiadL2vVlIjjfs9tapY0A=

--- a/models/clan_test.go
+++ b/models/clan_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Clan Model", func() {
 
 		testDb, err = GetTestDB()
 		Expect(err).NotTo(HaveOccurred())
-		testMongo, err = GetTestMongo()
+		testMongo, err = testing.GetTestMongo()
 		Expect(err).NotTo(HaveOccurred())
 
 		fixtures.ConfigureAndStartGoWorkers()
@@ -49,8 +49,11 @@ var _ = Describe("Clan Model", func() {
 	Describe("Clan Model", func() {
 		Describe("Basic Operations", func() {
 			It("Should sort clans by name", func() {
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
 				gameID := uuid.NewV4().String()
-				_, clans, err := fixtures.CreateTestClans(testDb, gameID, "test-sort-clan", 10, fixtures.EnqueueClanForMongoUpdate)
+				_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, gameID, "test-sort-clan", 10, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 
 				sort.Sort(ClanByName(clans))
@@ -61,7 +64,10 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should create a new Clan", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 				Expect(clan.ID).NotTo(BeEquivalentTo(0))
@@ -74,7 +80,10 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should update a Clan", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -91,7 +100,10 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Id", func() {
 			It("Should get existing Clan", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -109,7 +121,10 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Public Id", func() {
 			It("Should get an existing Clan by Game and PublicID", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -127,7 +142,10 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Public Id", func() {
 			It("Should get an existing Clan by Game and PublicID prefix", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -214,7 +232,10 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get By Public Id and OwnerPublicID", func() {
 			It("Should get an existing Clan by Game, PublicID and OwnerPublicID", func() {
-				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				player, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -234,7 +255,10 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not get a existing Clan by Game, PublicID and OwnerPublicID if not Clan owner", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -412,7 +436,10 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Update Clan", func() {
 			It("Should update a Clan with UpdateClan", func() {
-				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				player, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -443,7 +470,10 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not update a Clan if player is not the clan owner with UpdateClan", func() {
-				_, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				_, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -472,7 +502,10 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should not update a Clan with Invalid Data with UpdateClan", func() {
-				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				player, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -493,7 +526,10 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			Measure("Should update a Clan with UpdateClan", func(b Benchmarker) {
-				player, clans, err := fixtures.CreateTestClans(testDb, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				player, clans, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 1, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 				clan := clans[0]
 
@@ -735,7 +771,10 @@ var _ = Describe("Clan Model", func() {
 
 		Describe("Get List of Clans", func() {
 			It("Should get all clans", func() {
-				player, _, err := fixtures.CreateTestClans(testDb, "", "", 10, fixtures.EnqueueClanForMongoUpdate)
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
+				player, _, err := fixtures.CreateTestClans(testDb, mongoDB, "", "", 10, fixtures.EnqueueClanForMongoUpdate)
 				Expect(err).NotTo(HaveOccurred())
 
 				clans, err := GetAllClans(testDb, player.GameID)
@@ -1174,23 +1213,21 @@ var _ = Describe("Clan Model", func() {
 			var realClans []*Clan
 
 			BeforeEach(func() {
-				var err error
+				mongoDB, err := testing.GetTestMongo()
+				Expect(err).NotTo(HaveOccurred())
+
 				player, realClans, err = fixtures.CreateTestClans(
-					testDb, "", "clan-search-clan", 10, fixtures.EnqueueClanForMongoUpdate,
+					testDb, mongoDB, "", "clan-search-clan", 10, fixtures.EnqueueClanForMongoUpdate,
 				)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(500 * time.Millisecond)
 			})
 
 			It("Should return clan by search term", func() {
-				err := testing.CreateClanNameTextIndexInMongo(GetTestMongo, player.GameID)
-				Expect(err).NotTo(HaveOccurred())
 				Eventually(func() ([]Clan, error) { return SearchClan(testDb, testMongo, player.GameID, "SEARCH", 10) }).Should(HaveLen(10))
 			})
 
 			It("Should return clan by unicode search term", func() {
-				err := testing.CreateClanNameTextIndexInMongo(GetTestMongo, player.GameID)
-				Expect(err).NotTo(HaveOccurred())
 				Eventually(func() ([]Clan, error) { return SearchClan(testDb, testMongo, player.GameID, "💩clán", 10) }).Should(HaveLen(10))
 			})
 
@@ -1207,8 +1244,6 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should return empty list if search term is not found", func() {
-				err := testing.CreateClanNameTextIndexInMongo(GetTestMongo, player.GameID)
-				Expect(err).NotTo(HaveOccurred())
 				Eventually(func() ([]Clan, error) { return SearchClan(testDb, testMongo, player.GameID, "qwfjur", 10) }).Should(HaveLen(0))
 			})
 
@@ -1219,9 +1254,8 @@ var _ = Describe("Clan Model", func() {
 			})
 
 			It("Should return clan by word prefix", func() {
-				err := testing.CreateClanNameTextIndexInMongo(GetTestMongo, player.GameID)
-				Expect(err).NotTo(HaveOccurred())
 				dbClan, err := fixtures.GetTestClanWithName(testDb, player.GameID, "The Largest Clan Name For Prefix Test", player.ID)
+				Expect(err).NotTo(HaveOccurred())
 				Eventually(func() (string, error) {
 					clans, err := SearchClan(testDb, testMongo, player.GameID, "prefi large", 10)
 					if err != nil {

--- a/models/fixtures/fixtures.go
+++ b/models/fixtures/fixtures.go
@@ -18,7 +18,9 @@ import (
 	"github.com/jrallison/go-workers"
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/viper"
+	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/models"
+	"github.com/topfreegames/khan/mongo"
 	"github.com/topfreegames/khan/queues"
 	kt "github.com/topfreegames/khan/testing"
 	"github.com/topfreegames/khan/util"
@@ -502,7 +504,7 @@ func EnqueueClanForMongoUpdate(player *models.Player, clan *models.Clan) error {
 
 // CreateTestClans returns a list of clans for tests
 func CreateTestClans(
-	db models.DB, gameID string, publicIDTemplate string, numberOfClans int, afterCreationHook AfterClanCreationHook,
+	db models.DB, mongoDB interfaces.MongoDB, gameID string, publicIDTemplate string, numberOfClans int, afterCreationHook AfterClanCreationHook,
 ) (*models.Player, []*models.Clan, error) {
 	if gameID == "" {
 		gameID = uuid.NewV4().String()
@@ -546,6 +548,11 @@ func CreateTestClans(
 		}
 
 		clans = append(clans, clan)
+	}
+
+	err = mongoDB.Run(mongo.GetClanNameTextIndexCommand(gameID, false), nil)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return player, clans, nil

--- a/models/game.go
+++ b/models/game.go
@@ -186,28 +186,28 @@ func CreateGame(
 	}
 
 	_, err = db.Exec(query,
-		publicID,                                       // $1
-		name,                                           // $2
-		minLevelAccept,                                 // $3
-		minLevelCreate,                                 // $4
-		minLevelRemove,                                 // $5
-		minOffsetRemove,                                // $6
-		minOffsetPromote,                               // $7
-		minOffsetDemote,                                // $8
-		maxMembers,                                     // $9
-		maxClans,                                       // $10
-		levelsJSON,                                     // $11
-		metadataJSON,                                   // $12
-		cooldownAfterDelete,                            // $13
-		cooldownAfterDeny,                              // $14
-		cooldownBeforeApply,                            // $15
-		cooldownBeforeInvite,                           // $16
-		minMembershipLevel,                             // $17
-		maxMembershipLevel,                             // $18
-		maxPendingInvites,                              // $19
+		publicID,             // $1
+		name,                 // $2
+		minLevelAccept,       // $3
+		minLevelCreate,       // $4
+		minLevelRemove,       // $5
+		minOffsetRemove,      // $6
+		minOffsetPromote,     // $7
+		minOffsetDemote,      // $8
+		maxMembers,           // $9
+		maxClans,             // $10
+		levelsJSON,           // $11
+		metadataJSON,         // $12
+		cooldownAfterDelete,  // $13
+		cooldownAfterDeny,    // $14
+		cooldownBeforeApply,  // $15
+		cooldownBeforeInvite, // $16
+		minMembershipLevel,   // $17
+		maxMembershipLevel,   // $18
+		maxPendingInvites,    // $19
 		clanUpdateMetadataFieldsHookTriggerWhitelist,   // $20
 		playerUpdateMetadataFieldsHookTriggerWhitelist, // $21
-		util.NowMilli(),                                // $22
+		util.NowMilli(), // $22
 	)
 	if err != nil {
 		return nil, err

--- a/models/helpers_test.go
+++ b/models/helpers_test.go
@@ -8,29 +8,13 @@
 package models_test
 
 import (
-	"github.com/spf13/viper"
 	egorp "github.com/topfreegames/extensions/v9/gorp/interfaces"
-	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/models"
-	"github.com/topfreegames/khan/mongo"
-	kt "github.com/topfreegames/khan/testing"
 )
 
 // GetTestDB returns a connection to the test database
 func GetTestDB() (egorp.Database, error) {
 	return models.GetDB("localhost", "khan_test", 5433, "disable", "khan_test", "")
-}
-
-func GetTestMongo() (interfaces.MongoDB, error) {
-	config := viper.New()
-	config.SetConfigType("yaml")
-	config.SetConfigFile("../config/test.yaml")
-	err := config.ReadInConfig()
-	if err != nil {
-		return nil, err
-	}
-	logger := kt.NewMockLogger()
-	return mongo.GetMongo(logger, config)
 }
 
 // GetFaultyTestDB returns an ill-configured test database

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -11,15 +11,6 @@ import (
 	"github.com/topfreegames/khan/models"
 )
 
-// // CreateClanNameTextIndexInMongo creates the necessary text index for clan search in mongo
-// func CreateClanNameTextIndexInMongo(getTestMongo func() (interfaces.MongoDB, error), gameID string) error {
-// 	db, err := getTestMongo()
-// 	if err != nil {
-// 		return err
-// 	}
-// 	return db.Run(mongo.GetClanNameTextIndexCommand(gameID, false), nil)
-// }
-
 var testDB models.DB
 
 // GetTestDB returns a connection to the test database.

--- a/testing/helpers.go
+++ b/testing/helpers.go
@@ -8,19 +8,17 @@ import (
 	"github.com/topfreegames/khan/util"
 
 	gocache "github.com/patrickmn/go-cache"
-	"github.com/topfreegames/extensions/v9/mongo/interfaces"
 	"github.com/topfreegames/khan/models"
-	"github.com/topfreegames/khan/mongo"
 )
 
-// CreateClanNameTextIndexInMongo creates the necessary text index for clan search in mongo
-func CreateClanNameTextIndexInMongo(getTestMongo func() (interfaces.MongoDB, error), gameID string) error {
-	db, err := getTestMongo()
-	if err != nil {
-		return err
-	}
-	return db.Run(mongo.GetClanNameTextIndexCommand(gameID, false), nil)
-}
+// // CreateClanNameTextIndexInMongo creates the necessary text index for clan search in mongo
+// func CreateClanNameTextIndexInMongo(getTestMongo func() (interfaces.MongoDB, error), gameID string) error {
+// 	db, err := getTestMongo()
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return db.Run(mongo.GetClanNameTextIndexCommand(gameID, false), nil)
+// }
 
 var testDB models.DB
 

--- a/testing/mongo.go
+++ b/testing/mongo.go
@@ -1,0 +1,20 @@
+package testing
+
+import (
+	"github.com/spf13/viper"
+	"github.com/topfreegames/extensions/v9/mongo/interfaces"
+	"github.com/topfreegames/khan/mongo"
+)
+
+// GetTestMongo returns a mongo instance for testing
+func GetTestMongo() (interfaces.MongoDB, error) {
+	config := viper.New()
+	config.SetConfigType("yaml")
+	config.SetConfigFile("../config/test.yaml")
+	err := config.ReadInConfig()
+	if err != nil {
+		return nil, err
+	}
+	logger := NewMockLogger()
+	return mongo.GetMongo(logger, config)
+}


### PR DESCRIPTION
Today, when a new game is created, a migration needs to be executed to ensure that the clan search by name works. This PR makes the create game endpoint create this index.