### PR TITLE
Improve text search route

### DIFF
--- a/mongo/helpers.go
+++ b/mongo/helpers.go
@@ -16,6 +16,10 @@ func GetClanNameTextIndexCommand(gameID string, background bool) bson.D {
 					"name":         "text",
 					"namePrefixes": "text",
 				},
+				"weights": bson.M{
+					"name":         256,
+					"namePrefixes": 1,
+				},
 				"name":             fmt.Sprintf("clans_%s_name_text_namePrefixes_text_index", gameID),
 				"background":       background,
 				"default_language": "none",


### PR DESCRIPTION
### Why
One of our games is facing a problem that a  clan with a certain name isn't returning in a search. The problem is that it doesn't assign weights to the search, and with that `textPrefixes` have more priority than `name` field. This PR proposes to set more weight in the search to `name` field instead `textPrefixes`.

### What was done
* Set weight of `name` field as 256 (high value than the maximum `namePrefixes` array length)